### PR TITLE
refactor: simplify SDK Public API

### DIFF
--- a/src/main/java/com/zitadel/api/ActionServiceApi.java
+++ b/src/main/java/com/zitadel/api/ActionServiceApi.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceApi extends BaseApi {
 
   public ActionServiceApi() {
@@ -63,7 +63,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaCreateTargetResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaCreateTargetResponse actionServiceCreateTarget(ActionServiceCreateTargetRequest actionServiceCreateTargetRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaCreateTargetResponse actionServiceCreateTarget(ActionServiceCreateTargetRequest actionServiceCreateTargetRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = actionServiceCreateTargetRequest;
     
     if (actionServiceCreateTargetRequest == null) {
@@ -135,7 +135,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaDeleteTargetResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaDeleteTargetResponse actionServiceDeleteTarget(String id, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaDeleteTargetResponse actionServiceDeleteTarget(String id, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (id == null) {
@@ -208,7 +208,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaGetTargetResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaGetTargetResponse actionServiceGetTarget(String id, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaGetTargetResponse actionServiceGetTarget(String id, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (id == null) {
@@ -279,7 +279,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaListExecutionFunctionsResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaListExecutionFunctionsResponse actionServiceListExecutionFunctions(Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaListExecutionFunctionsResponse actionServiceListExecutionFunctions(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2beta/actions/executions/functions";
@@ -345,7 +345,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaListExecutionMethodsResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaListExecutionMethodsResponse actionServiceListExecutionMethods(Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaListExecutionMethodsResponse actionServiceListExecutionMethods(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2beta/actions/executions/methods";
@@ -411,7 +411,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaListExecutionServicesResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaListExecutionServicesResponse actionServiceListExecutionServices(Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaListExecutionServicesResponse actionServiceListExecutionServices(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2beta/actions/executions/services";
@@ -485,7 +485,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaListExecutionsResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaListExecutionsResponse actionServiceListExecutions(String paginationOffset, Long paginationLimit, Boolean paginationAsc, String sortingColumn, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaListExecutionsResponse actionServiceListExecutions(String paginationOffset, Long paginationLimit, Boolean paginationAsc, String sortingColumn, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2beta/actions/executions/_search";
@@ -557,7 +557,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaListTargetsResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaListTargetsResponse actionServiceListTargets(ActionServiceListTargetsRequest actionServiceListTargetsRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaListTargetsResponse actionServiceListTargets(ActionServiceListTargetsRequest actionServiceListTargetsRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = actionServiceListTargetsRequest;
     
     if (actionServiceListTargetsRequest == null) {
@@ -629,7 +629,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaSetExecutionResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaSetExecutionResponse actionServiceSetExecution(ActionServiceSetExecutionRequest actionServiceSetExecutionRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaSetExecutionResponse actionServiceSetExecution(ActionServiceSetExecutionRequest actionServiceSetExecutionRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = actionServiceSetExecutionRequest;
     
     if (actionServiceSetExecutionRequest == null) {
@@ -703,7 +703,7 @@ public class ActionServiceApi extends BaseApi {
    * @return ActionServiceBetaUpdateTargetResponse
    * @throws ApiException if fails to make API call
    */
-  public ActionServiceBetaUpdateTargetResponse actionServiceUpdateTarget(String id, ActionServiceUpdateTargetRequest actionServiceUpdateTargetRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private ActionServiceBetaUpdateTargetResponse actionServiceUpdateTarget(String id, ActionServiceUpdateTargetRequest actionServiceUpdateTargetRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = actionServiceUpdateTargetRequest;
     
     if (id == null) {

--- a/src/main/java/com/zitadel/api/FeatureServiceApi.java
+++ b/src/main/java/com/zitadel/api/FeatureServiceApi.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceApi extends BaseApi {
 
   public FeatureServiceApi() {
@@ -63,7 +63,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceGetInstanceFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceGetInstanceFeaturesResponse featureServiceGetInstanceFeatures(Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceGetInstanceFeaturesResponse featureServiceGetInstanceFeatures(Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/features/instance";
@@ -134,7 +134,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceGetOrganizationFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceGetOrganizationFeaturesResponse featureServiceGetOrganizationFeatures(String organizationId, Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceGetOrganizationFeaturesResponse featureServiceGetOrganizationFeatures(String organizationId, Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (organizationId == null) {
@@ -206,7 +206,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceGetSystemFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceGetSystemFeaturesResponse featureServiceGetSystemFeatures(Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceGetSystemFeaturesResponse featureServiceGetSystemFeatures(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/features/system";
@@ -276,7 +276,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceGetUserFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceGetUserFeaturesResponse featureServiceGetUserFeatures(String userId, Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceGetUserFeaturesResponse featureServiceGetUserFeatures(String userId, Boolean inheritance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -348,7 +348,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceResetInstanceFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceResetInstanceFeaturesResponse featureServiceResetInstanceFeatures(Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceResetInstanceFeaturesResponse featureServiceResetInstanceFeatures(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/features/instance";
@@ -416,7 +416,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceResetOrganizationFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceResetOrganizationFeaturesResponse featureServiceResetOrganizationFeatures(String organizationId, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceResetOrganizationFeaturesResponse featureServiceResetOrganizationFeatures(String organizationId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (organizationId == null) {
@@ -487,7 +487,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceResetSystemFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceResetSystemFeaturesResponse featureServiceResetSystemFeatures(Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceResetSystemFeaturesResponse featureServiceResetSystemFeatures(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/features/system";
@@ -555,7 +555,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceResetUserFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceResetUserFeaturesResponse featureServiceResetUserFeatures(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceResetUserFeaturesResponse featureServiceResetUserFeatures(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -628,7 +628,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceSetInstanceFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceSetInstanceFeaturesResponse featureServiceSetInstanceFeatures(FeatureServiceSetInstanceFeaturesRequest featureServiceSetInstanceFeaturesRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceSetInstanceFeaturesResponse featureServiceSetInstanceFeatures(FeatureServiceSetInstanceFeaturesRequest featureServiceSetInstanceFeaturesRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = featureServiceSetInstanceFeaturesRequest;
     
     if (featureServiceSetInstanceFeaturesRequest == null) {
@@ -700,7 +700,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceSetOrganizationFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceSetOrganizationFeaturesResponse featureServiceSetOrganizationFeatures(String organizationId, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceSetOrganizationFeaturesResponse featureServiceSetOrganizationFeatures(String organizationId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (organizationId == null) {
@@ -729,7 +729,7 @@ public class FeatureServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -773,7 +773,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceSetSystemFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceSetSystemFeaturesResponse featureServiceSetSystemFeatures(FeatureServiceSetSystemFeaturesRequest featureServiceSetSystemFeaturesRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceSetSystemFeaturesResponse featureServiceSetSystemFeatures(FeatureServiceSetSystemFeaturesRequest featureServiceSetSystemFeaturesRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = featureServiceSetSystemFeaturesRequest;
     
     if (featureServiceSetSystemFeaturesRequest == null) {
@@ -845,7 +845,7 @@ public class FeatureServiceApi extends BaseApi {
    * @return FeatureServiceSetUserFeaturesResponse
    * @throws ApiException if fails to make API call
    */
-  public FeatureServiceSetUserFeaturesResponse featureServiceSetUserFeatures(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private FeatureServiceSetUserFeaturesResponse featureServiceSetUserFeatures(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -874,7 +874,7 @@ public class FeatureServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -916,7 +916,7 @@ public class FeatureServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 

--- a/src/main/java/com/zitadel/api/IdentityProviderServiceApi.java
+++ b/src/main/java/com/zitadel/api/IdentityProviderServiceApi.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceApi extends BaseApi {
 
   public IdentityProviderServiceApi() {
@@ -50,7 +50,7 @@ public class IdentityProviderServiceApi extends BaseApi {
    * @return IdentityProviderServiceGetIDPByIDResponse
    * @throws ApiException if fails to make API call
    */
-  public IdentityProviderServiceGetIDPByIDResponse identityProviderServiceGetIDPByID(String id, Map<String, String> additionalHeaders) throws ApiException {
+  private IdentityProviderServiceGetIDPByIDResponse identityProviderServiceGetIDPByID(String id, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (id == null) {

--- a/src/main/java/com/zitadel/api/OidcServiceApi.java
+++ b/src/main/java/com/zitadel/api/OidcServiceApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OidcServiceApi extends BaseApi {
 
   public OidcServiceApi() {
@@ -56,7 +56,7 @@ public class OidcServiceApi extends BaseApi {
    * @return Object
    * @throws ApiException if fails to make API call
    */
-  public Object oIDCServiceAuthorizeOrDenyDeviceAuthorization(String deviceAuthorizationId, OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest oiDCServiceAuthorizeOrDenyDeviceAuthorizationRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private Object oIDCServiceAuthorizeOrDenyDeviceAuthorization(String deviceAuthorizationId, OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest oiDCServiceAuthorizeOrDenyDeviceAuthorizationRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = oiDCServiceAuthorizeOrDenyDeviceAuthorizationRequest;
     
     if (deviceAuthorizationId == null) {
@@ -135,7 +135,7 @@ public class OidcServiceApi extends BaseApi {
    * @return OIDCServiceCreateCallbackResponse
    * @throws ApiException if fails to make API call
    */
-  public OIDCServiceCreateCallbackResponse oIDCServiceCreateCallback(String authRequestId, OIDCServiceCreateCallbackRequest oiDCServiceCreateCallbackRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private OIDCServiceCreateCallbackResponse oIDCServiceCreateCallback(String authRequestId, OIDCServiceCreateCallbackRequest oiDCServiceCreateCallbackRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = oiDCServiceCreateCallbackRequest;
     
     if (authRequestId == null) {
@@ -212,7 +212,7 @@ public class OidcServiceApi extends BaseApi {
    * @return OIDCServiceGetAuthRequestResponse
    * @throws ApiException if fails to make API call
    */
-  public OIDCServiceGetAuthRequestResponse oIDCServiceGetAuthRequest(String authRequestId, Map<String, String> additionalHeaders) throws ApiException {
+  private OIDCServiceGetAuthRequestResponse oIDCServiceGetAuthRequest(String authRequestId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (authRequestId == null) {
@@ -285,7 +285,7 @@ public class OidcServiceApi extends BaseApi {
    * @return OIDCServiceGetDeviceAuthorizationRequestResponse
    * @throws ApiException if fails to make API call
    */
-  public OIDCServiceGetDeviceAuthorizationRequestResponse oIDCServiceGetDeviceAuthorizationRequest(String userCode, Map<String, String> additionalHeaders) throws ApiException {
+  private OIDCServiceGetDeviceAuthorizationRequestResponse oIDCServiceGetDeviceAuthorizationRequest(String userCode, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userCode == null) {

--- a/src/main/java/com/zitadel/api/OrganizationServiceApi.java
+++ b/src/main/java/com/zitadel/api/OrganizationServiceApi.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceApi extends BaseApi {
 
   public OrganizationServiceApi() {
@@ -53,7 +53,7 @@ public class OrganizationServiceApi extends BaseApi {
    * @return OrganizationServiceAddOrganizationResponse
    * @throws ApiException if fails to make API call
    */
-  public OrganizationServiceAddOrganizationResponse organizationServiceAddOrganization(OrganizationServiceAddOrganizationRequest organizationServiceAddOrganizationRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private OrganizationServiceAddOrganizationResponse organizationServiceAddOrganization(OrganizationServiceAddOrganizationRequest organizationServiceAddOrganizationRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = organizationServiceAddOrganizationRequest;
     
     if (organizationServiceAddOrganizationRequest == null) {
@@ -125,7 +125,7 @@ public class OrganizationServiceApi extends BaseApi {
    * @return OrganizationServiceListOrganizationsResponse
    * @throws ApiException if fails to make API call
    */
-  public OrganizationServiceListOrganizationsResponse organizationServiceListOrganizations(OrganizationServiceListOrganizationsRequest organizationServiceListOrganizationsRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private OrganizationServiceListOrganizationsResponse organizationServiceListOrganizations(OrganizationServiceListOrganizationsRequest organizationServiceListOrganizationsRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = organizationServiceListOrganizationsRequest;
     
     if (organizationServiceListOrganizationsRequest == null) {

--- a/src/main/java/com/zitadel/api/SamlServiceApi.java
+++ b/src/main/java/com/zitadel/api/SamlServiceApi.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SamlServiceApi extends BaseApi {
 
   public SamlServiceApi() {
@@ -54,7 +54,7 @@ public class SamlServiceApi extends BaseApi {
    * @return SAMLServiceCreateResponseResponse
    * @throws ApiException if fails to make API call
    */
-  public SAMLServiceCreateResponseResponse sAMLServiceCreateResponse(String samlRequestId, SAMLServiceCreateResponseRequest saMLServiceCreateResponseRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SAMLServiceCreateResponseResponse sAMLServiceCreateResponse(String samlRequestId, SAMLServiceCreateResponseRequest saMLServiceCreateResponseRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = saMLServiceCreateResponseRequest;
     
     if (samlRequestId == null) {
@@ -131,7 +131,7 @@ public class SamlServiceApi extends BaseApi {
    * @return SAMLServiceGetSAMLRequestResponse
    * @throws ApiException if fails to make API call
    */
-  public SAMLServiceGetSAMLRequestResponse sAMLServiceGetSAMLRequest(String samlRequestId, Map<String, String> additionalHeaders) throws ApiException {
+  private SAMLServiceGetSAMLRequestResponse sAMLServiceGetSAMLRequest(String samlRequestId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (samlRequestId == null) {

--- a/src/main/java/com/zitadel/api/SessionServiceApi.java
+++ b/src/main/java/com/zitadel/api/SessionServiceApi.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceApi extends BaseApi {
 
   public SessionServiceApi() {
@@ -58,7 +58,7 @@ public class SessionServiceApi extends BaseApi {
    * @return SessionServiceCreateSessionResponse
    * @throws ApiException if fails to make API call
    */
-  public SessionServiceCreateSessionResponse sessionServiceCreateSession(SessionServiceCreateSessionRequest sessionServiceCreateSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SessionServiceCreateSessionResponse sessionServiceCreateSession(SessionServiceCreateSessionRequest sessionServiceCreateSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = sessionServiceCreateSessionRequest;
     
     if (sessionServiceCreateSessionRequest == null) {
@@ -132,7 +132,7 @@ public class SessionServiceApi extends BaseApi {
    * @return SessionServiceDeleteSessionResponse
    * @throws ApiException if fails to make API call
    */
-  public SessionServiceDeleteSessionResponse sessionServiceDeleteSession(String sessionId, SessionServiceDeleteSessionRequest sessionServiceDeleteSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SessionServiceDeleteSessionResponse sessionServiceDeleteSession(String sessionId, SessionServiceDeleteSessionRequest sessionServiceDeleteSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = sessionServiceDeleteSessionRequest;
     
     if (sessionId == null) {
@@ -211,7 +211,7 @@ public class SessionServiceApi extends BaseApi {
    * @return SessionServiceGetSessionResponse
    * @throws ApiException if fails to make API call
    */
-  public SessionServiceGetSessionResponse sessionServiceGetSession(String sessionId, String sessionToken, Map<String, String> additionalHeaders) throws ApiException {
+  private SessionServiceGetSessionResponse sessionServiceGetSession(String sessionId, String sessionToken, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (sessionId == null) {
@@ -285,7 +285,7 @@ public class SessionServiceApi extends BaseApi {
    * @return SessionServiceListSessionsResponse
    * @throws ApiException if fails to make API call
    */
-  public SessionServiceListSessionsResponse sessionServiceListSessions(SessionServiceListSessionsRequest sessionServiceListSessionsRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SessionServiceListSessionsResponse sessionServiceListSessions(SessionServiceListSessionsRequest sessionServiceListSessionsRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = sessionServiceListSessionsRequest;
     
     if (sessionServiceListSessionsRequest == null) {
@@ -359,7 +359,7 @@ public class SessionServiceApi extends BaseApi {
    * @return SessionServiceSetSessionResponse
    * @throws ApiException if fails to make API call
    */
-  public SessionServiceSetSessionResponse sessionServiceSetSession(String sessionId, SessionServiceSetSessionRequest sessionServiceSetSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SessionServiceSetSessionResponse sessionServiceSetSession(String sessionId, SessionServiceSetSessionRequest sessionServiceSetSessionRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = sessionServiceSetSessionRequest;
     
     if (sessionId == null) {

--- a/src/main/java/com/zitadel/api/SettingsServiceApi.java
+++ b/src/main/java/com/zitadel/api/SettingsServiceApi.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceApi extends BaseApi {
 
   public SettingsServiceApi() {
@@ -71,7 +71,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetActiveIdentityProvidersResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetActiveIdentityProvidersResponse settingsServiceGetActiveIdentityProviders(String ctxOrgId, Boolean ctxInstance, Boolean creationAllowed, Boolean linkingAllowed, Boolean autoCreation, Boolean autoLinking, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetActiveIdentityProvidersResponse settingsServiceGetActiveIdentityProviders(String ctxOrgId, Boolean ctxInstance, Boolean creationAllowed, Boolean linkingAllowed, Boolean autoCreation, Boolean autoLinking, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/login/idps";
@@ -147,7 +147,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetBrandingSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetBrandingSettingsResponse settingsServiceGetBrandingSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetBrandingSettingsResponse settingsServiceGetBrandingSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/branding";
@@ -219,7 +219,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetDomainSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetDomainSettingsResponse settingsServiceGetDomainSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetDomainSettingsResponse settingsServiceGetDomainSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/domain";
@@ -287,7 +287,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetGeneralSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetGeneralSettingsResponse settingsServiceGetGeneralSettings(Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetGeneralSettingsResponse settingsServiceGetGeneralSettings(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings";
@@ -357,7 +357,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetLegalAndSupportSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetLegalAndSupportSettingsResponse settingsServiceGetLegalAndSupportSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetLegalAndSupportSettingsResponse settingsServiceGetLegalAndSupportSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/legal_support";
@@ -429,7 +429,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetLockoutSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetLockoutSettingsResponse settingsServiceGetLockoutSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetLockoutSettingsResponse settingsServiceGetLockoutSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/lockout";
@@ -501,7 +501,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetLoginSettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetLoginSettingsResponse settingsServiceGetLoginSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetLoginSettingsResponse settingsServiceGetLoginSettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/login";
@@ -573,7 +573,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetPasswordComplexitySettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetPasswordComplexitySettingsResponse settingsServiceGetPasswordComplexitySettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetPasswordComplexitySettingsResponse settingsServiceGetPasswordComplexitySettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/password/complexity";
@@ -645,7 +645,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetPasswordExpirySettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetPasswordExpirySettingsResponse settingsServiceGetPasswordExpirySettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetPasswordExpirySettingsResponse settingsServiceGetPasswordExpirySettings(String ctxOrgId, Boolean ctxInstance, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/password/expiry";
@@ -713,7 +713,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceGetSecuritySettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceGetSecuritySettingsResponse settingsServiceGetSecuritySettings(Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceGetSecuritySettingsResponse settingsServiceGetSecuritySettings(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2/settings/security";
@@ -781,7 +781,7 @@ public class SettingsServiceApi extends BaseApi {
    * @return SettingsServiceSetSecuritySettingsResponse
    * @throws ApiException if fails to make API call
    */
-  public SettingsServiceSetSecuritySettingsResponse settingsServiceSetSecuritySettings(SettingsServiceSetSecuritySettingsRequest settingsServiceSetSecuritySettingsRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private SettingsServiceSetSecuritySettingsResponse settingsServiceSetSecuritySettings(SettingsServiceSetSecuritySettingsRequest settingsServiceSetSecuritySettingsRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = settingsServiceSetSecuritySettingsRequest;
     
     if (settingsServiceSetSecuritySettingsRequest == null) {

--- a/src/main/java/com/zitadel/api/UserServiceApi.java
+++ b/src/main/java/com/zitadel/api/UserServiceApi.java
@@ -87,7 +87,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceApi extends BaseApi {
 
   public UserServiceApi() {
@@ -118,7 +118,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceAddHumanUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceAddHumanUserResponse userServiceAddHumanUser(UserServiceAddHumanUserRequest userServiceAddHumanUserRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceAddHumanUserResponse userServiceAddHumanUser(UserServiceAddHumanUserRequest userServiceAddHumanUserRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceAddHumanUserRequest;
     
     if (userServiceAddHumanUserRequest == null) {
@@ -192,7 +192,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceAddIDPLinkResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceAddIDPLinkResponse userServiceAddIDPLink(String userId, UserServiceAddIDPLinkRequest userServiceAddIDPLinkRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceAddIDPLinkResponse userServiceAddIDPLink(String userId, UserServiceAddIDPLinkRequest userServiceAddIDPLinkRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceAddIDPLinkRequest;
     
     if (userId == null) {
@@ -269,7 +269,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceAddOTPEmailResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceAddOTPEmailResponse userServiceAddOTPEmail(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceAddOTPEmailResponse userServiceAddOTPEmail(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -298,7 +298,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -342,7 +342,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceAddOTPSMSResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceAddOTPSMSResponse userServiceAddOTPSMS(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceAddOTPSMSResponse userServiceAddOTPSMS(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -371,7 +371,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -417,7 +417,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceCreateInviteCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceCreateInviteCodeResponse userServiceCreateInviteCode(String userId, UserServiceCreateInviteCodeRequest userServiceCreateInviteCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceCreateInviteCodeResponse userServiceCreateInviteCode(String userId, UserServiceCreateInviteCodeRequest userServiceCreateInviteCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceCreateInviteCodeRequest;
     
     if (userId == null) {
@@ -496,7 +496,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceCreatePasskeyRegistrationLinkResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceCreatePasskeyRegistrationLinkResponse userServiceCreatePasskeyRegistrationLink(String userId, UserServiceCreatePasskeyRegistrationLinkRequest userServiceCreatePasskeyRegistrationLinkRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceCreatePasskeyRegistrationLinkResponse userServiceCreatePasskeyRegistrationLink(String userId, UserServiceCreatePasskeyRegistrationLinkRequest userServiceCreatePasskeyRegistrationLinkRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceCreatePasskeyRegistrationLinkRequest;
     
     if (userId == null) {
@@ -573,7 +573,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceDeactivateUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceDeactivateUserResponse userServiceDeactivateUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceDeactivateUserResponse userServiceDeactivateUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -602,7 +602,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -646,7 +646,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceDeleteUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceDeleteUserResponse userServiceDeleteUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceDeleteUserResponse userServiceDeleteUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -719,7 +719,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceGetUserByIDResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceGetUserByIDResponse userServiceGetUserByID(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceGetUserByIDResponse userServiceGetUserByID(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -792,7 +792,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceHumanMFAInitSkippedResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceHumanMFAInitSkippedResponse userServiceHumanMFAInitSkipped(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceHumanMFAInitSkippedResponse userServiceHumanMFAInitSkipped(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -821,7 +821,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -869,7 +869,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceListAuthenticationFactorsResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceListAuthenticationFactorsResponse userServiceListAuthenticationFactors(String userId, List<String> authFactors, List<String> states, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceListAuthenticationFactorsResponse userServiceListAuthenticationFactors(String userId, List<String> authFactors, List<String> states, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -948,7 +948,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceListAuthenticationMethodTypesResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceListAuthenticationMethodTypesResponse userServiceListAuthenticationMethodTypes(String userId, Boolean domainQueryIncludeWithoutDomain, String domainQueryDomain, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceListAuthenticationMethodTypesResponse userServiceListAuthenticationMethodTypes(String userId, Boolean domainQueryIncludeWithoutDomain, String domainQueryDomain, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1025,7 +1025,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceListIDPLinksResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceListIDPLinksResponse userServiceListIDPLinks(String userId, UserServiceListIDPLinksRequest userServiceListIDPLinksRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceListIDPLinksResponse userServiceListIDPLinks(String userId, UserServiceListIDPLinksRequest userServiceListIDPLinksRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceListIDPLinksRequest;
     
     if (userId == null) {
@@ -1102,7 +1102,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceListPasskeysResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceListPasskeysResponse userServiceListPasskeys(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceListPasskeysResponse userServiceListPasskeys(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1131,7 +1131,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -1175,7 +1175,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceListUsersResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceListUsersResponse userServiceListUsers(UserServiceListUsersRequest userServiceListUsersRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceListUsersResponse userServiceListUsers(UserServiceListUsersRequest userServiceListUsersRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceListUsersRequest;
     
     if (userServiceListUsersRequest == null) {
@@ -1247,7 +1247,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceLockUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceLockUserResponse userServiceLockUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceLockUserResponse userServiceLockUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1276,7 +1276,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -1322,7 +1322,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServicePasswordResetResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServicePasswordResetResponse userServicePasswordReset(String userId, UserServicePasswordResetRequest userServicePasswordResetRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServicePasswordResetResponse userServicePasswordReset(String userId, UserServicePasswordResetRequest userServicePasswordResetRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServicePasswordResetRequest;
     
     if (userId == null) {
@@ -1399,7 +1399,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceReactivateUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceReactivateUserResponse userServiceReactivateUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceReactivateUserResponse userServiceReactivateUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1428,7 +1428,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -1474,7 +1474,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRegisterPasskeyResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRegisterPasskeyResponse userServiceRegisterPasskey(String userId, UserServiceRegisterPasskeyRequest userServiceRegisterPasskeyRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRegisterPasskeyResponse userServiceRegisterPasskey(String userId, UserServiceRegisterPasskeyRequest userServiceRegisterPasskeyRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceRegisterPasskeyRequest;
     
     if (userId == null) {
@@ -1551,7 +1551,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRegisterTOTPResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRegisterTOTPResponse userServiceRegisterTOTP(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRegisterTOTPResponse userServiceRegisterTOTP(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1580,7 +1580,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -1626,7 +1626,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRegisterU2FResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRegisterU2FResponse userServiceRegisterU2F(String userId, UserServiceRegisterU2FRequest userServiceRegisterU2FRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRegisterU2FResponse userServiceRegisterU2F(String userId, UserServiceRegisterU2FRequest userServiceRegisterU2FRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceRegisterU2FRequest;
     
     if (userId == null) {
@@ -1707,7 +1707,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemoveIDPLinkResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemoveIDPLinkResponse userServiceRemoveIDPLink(String userId, String idpId, String linkedUserId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemoveIDPLinkResponse userServiceRemoveIDPLink(String userId, String idpId, String linkedUserId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1746,7 +1746,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -1790,7 +1790,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemoveOTPEmailResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemoveOTPEmailResponse userServiceRemoveOTPEmail(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemoveOTPEmailResponse userServiceRemoveOTPEmail(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1863,7 +1863,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemoveOTPSMSResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemoveOTPSMSResponse userServiceRemoveOTPSMS(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemoveOTPSMSResponse userServiceRemoveOTPSMS(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -1938,7 +1938,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemovePasskeyResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemovePasskeyResponse userServiceRemovePasskey(String userId, String passkeyId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemovePasskeyResponse userServiceRemovePasskey(String userId, String passkeyId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2016,7 +2016,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemovePhoneResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemovePhoneResponse userServiceRemovePhone(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemovePhoneResponse userServiceRemovePhone(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2045,7 +2045,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -2089,7 +2089,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemoveTOTPResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemoveTOTPResponse userServiceRemoveTOTP(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemoveTOTPResponse userServiceRemoveTOTP(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2164,7 +2164,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRemoveU2FResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRemoveU2FResponse userServiceRemoveU2F(String userId, String u2fId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRemoveU2FResponse userServiceRemoveU2F(String userId, String u2fId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2244,7 +2244,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceResendEmailCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceResendEmailCodeResponse userServiceResendEmailCode(String userId, UserServiceResendEmailCodeRequest userServiceResendEmailCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceResendEmailCodeResponse userServiceResendEmailCode(String userId, UserServiceResendEmailCodeRequest userServiceResendEmailCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceResendEmailCodeRequest;
     
     if (userId == null) {
@@ -2321,7 +2321,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceResendInviteCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceResendInviteCodeResponse userServiceResendInviteCode(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceResendInviteCodeResponse userServiceResendInviteCode(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2396,7 +2396,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceResendPhoneCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceResendPhoneCodeResponse userServiceResendPhoneCode(String userId, UserServiceResendPhoneCodeRequest userServiceResendPhoneCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceResendPhoneCodeResponse userServiceResendPhoneCode(String userId, UserServiceResendPhoneCodeRequest userServiceResendPhoneCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceResendPhoneCodeRequest;
     
     if (userId == null) {
@@ -2475,7 +2475,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceRetrieveIdentityProviderIntentResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceRetrieveIdentityProviderIntentResponse userServiceRetrieveIdentityProviderIntent(String idpIntentId, UserServiceRetrieveIdentityProviderIntentRequest userServiceRetrieveIdentityProviderIntentRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceRetrieveIdentityProviderIntentResponse userServiceRetrieveIdentityProviderIntent(String idpIntentId, UserServiceRetrieveIdentityProviderIntentRequest userServiceRetrieveIdentityProviderIntentRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceRetrieveIdentityProviderIntentRequest;
     
     if (idpIntentId == null) {
@@ -2554,7 +2554,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceSendEmailCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceSendEmailCodeResponse userServiceSendEmailCode(String userId, UserServiceSendEmailCodeRequest userServiceSendEmailCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceSendEmailCodeResponse userServiceSendEmailCode(String userId, UserServiceSendEmailCodeRequest userServiceSendEmailCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceSendEmailCodeRequest;
     
     if (userId == null) {
@@ -2633,7 +2633,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceSetEmailResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceSetEmailResponse userServiceSetEmail(String userId, UserServiceSetEmailRequest userServiceSetEmailRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceSetEmailResponse userServiceSetEmail(String userId, UserServiceSetEmailRequest userServiceSetEmailRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceSetEmailRequest;
     
     if (userId == null) {
@@ -2712,7 +2712,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceSetPasswordResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceSetPasswordResponse userServiceSetPassword(String userId, UserServiceSetPasswordRequest userServiceSetPasswordRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceSetPasswordResponse userServiceSetPassword(String userId, UserServiceSetPasswordRequest userServiceSetPasswordRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceSetPasswordRequest;
     
     if (userId == null) {
@@ -2791,7 +2791,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceSetPhoneResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceSetPhoneResponse userServiceSetPhone(String userId, UserServiceSetPhoneRequest userServiceSetPhoneRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceSetPhoneResponse userServiceSetPhone(String userId, UserServiceSetPhoneRequest userServiceSetPhoneRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceSetPhoneRequest;
     
     if (userId == null) {
@@ -2868,7 +2868,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceStartIdentityProviderIntentResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceStartIdentityProviderIntentResponse userServiceStartIdentityProviderIntent(UserServiceStartIdentityProviderIntentRequest userServiceStartIdentityProviderIntentRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceStartIdentityProviderIntentResponse userServiceStartIdentityProviderIntent(UserServiceStartIdentityProviderIntentRequest userServiceStartIdentityProviderIntentRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceStartIdentityProviderIntentRequest;
     
     if (userServiceStartIdentityProviderIntentRequest == null) {
@@ -2940,7 +2940,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceUnlockUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceUnlockUserResponse userServiceUnlockUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceUnlockUserResponse userServiceUnlockUser(String userId, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (userId == null) {
@@ -2969,7 +2969,7 @@ public class UserServiceApi extends BaseApi {
     final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
     final String[] localVarContentTypes = {
-      "application/json"
+      
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
@@ -3015,7 +3015,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceUpdateHumanUserResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceUpdateHumanUserResponse userServiceUpdateHumanUser(String userId, UserServiceUpdateHumanUserRequest userServiceUpdateHumanUserRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceUpdateHumanUserResponse userServiceUpdateHumanUser(String userId, UserServiceUpdateHumanUserRequest userServiceUpdateHumanUserRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceUpdateHumanUserRequest;
     
     if (userId == null) {
@@ -3094,7 +3094,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyEmailResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyEmailResponse userServiceVerifyEmail(String userId, UserServiceVerifyEmailRequest userServiceVerifyEmailRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyEmailResponse userServiceVerifyEmail(String userId, UserServiceVerifyEmailRequest userServiceVerifyEmailRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyEmailRequest;
     
     if (userId == null) {
@@ -3173,7 +3173,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyInviteCodeResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyInviteCodeResponse userServiceVerifyInviteCode(String userId, UserServiceVerifyInviteCodeRequest userServiceVerifyInviteCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyInviteCodeResponse userServiceVerifyInviteCode(String userId, UserServiceVerifyInviteCodeRequest userServiceVerifyInviteCodeRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyInviteCodeRequest;
     
     if (userId == null) {
@@ -3254,7 +3254,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyPasskeyRegistrationResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyPasskeyRegistrationResponse userServiceVerifyPasskeyRegistration(String userId, String passkeyId, UserServiceVerifyPasskeyRegistrationRequest userServiceVerifyPasskeyRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyPasskeyRegistrationResponse userServiceVerifyPasskeyRegistration(String userId, String passkeyId, UserServiceVerifyPasskeyRegistrationRequest userServiceVerifyPasskeyRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyPasskeyRegistrationRequest;
     
     if (userId == null) {
@@ -3338,7 +3338,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyPhoneResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyPhoneResponse userServiceVerifyPhone(String userId, UserServiceVerifyPhoneRequest userServiceVerifyPhoneRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyPhoneResponse userServiceVerifyPhone(String userId, UserServiceVerifyPhoneRequest userServiceVerifyPhoneRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyPhoneRequest;
     
     if (userId == null) {
@@ -3417,7 +3417,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyTOTPRegistrationResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyTOTPRegistrationResponse userServiceVerifyTOTPRegistration(String userId, UserServiceVerifyTOTPRegistrationRequest userServiceVerifyTOTPRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyTOTPRegistrationResponse userServiceVerifyTOTPRegistration(String userId, UserServiceVerifyTOTPRegistrationRequest userServiceVerifyTOTPRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyTOTPRegistrationRequest;
     
     if (userId == null) {
@@ -3498,7 +3498,7 @@ public class UserServiceApi extends BaseApi {
    * @return UserServiceVerifyU2FRegistrationResponse
    * @throws ApiException if fails to make API call
    */
-  public UserServiceVerifyU2FRegistrationResponse userServiceVerifyU2FRegistration(String userId, String u2fId, UserServiceVerifyU2FRegistrationRequest userServiceVerifyU2FRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private UserServiceVerifyU2FRegistrationResponse userServiceVerifyU2FRegistration(String userId, String u2fId, UserServiceVerifyU2FRegistrationRequest userServiceVerifyU2FRegistrationRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = userServiceVerifyU2FRegistrationRequest;
     
     if (userId == null) {

--- a/src/main/java/com/zitadel/api/WebKeyServiceApi.java
+++ b/src/main/java/com/zitadel/api/WebKeyServiceApi.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceApi extends BaseApi {
 
   public WebKeyServiceApi() {
@@ -54,7 +54,7 @@ public class WebKeyServiceApi extends BaseApi {
    * @return WebKeyServiceBetaActivateWebKeyResponse
    * @throws ApiException if fails to make API call
    */
-  public WebKeyServiceBetaActivateWebKeyResponse webKeyServiceActivateWebKey(String id, Map<String, String> additionalHeaders) throws ApiException {
+  private WebKeyServiceBetaActivateWebKeyResponse webKeyServiceActivateWebKey(String id, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (id == null) {
@@ -127,7 +127,7 @@ public class WebKeyServiceApi extends BaseApi {
    * @return WebKeyServiceBetaCreateWebKeyResponse
    * @throws ApiException if fails to make API call
    */
-  public WebKeyServiceBetaCreateWebKeyResponse webKeyServiceCreateWebKey(WebKeyServiceCreateWebKeyRequest webKeyServiceCreateWebKeyRequest, Map<String, String> additionalHeaders) throws ApiException {
+  private WebKeyServiceBetaCreateWebKeyResponse webKeyServiceCreateWebKey(WebKeyServiceCreateWebKeyRequest webKeyServiceCreateWebKeyRequest, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = webKeyServiceCreateWebKeyRequest;
     
     if (webKeyServiceCreateWebKeyRequest == null) {
@@ -199,7 +199,7 @@ public class WebKeyServiceApi extends BaseApi {
    * @return WebKeyServiceBetaDeleteWebKeyResponse
    * @throws ApiException if fails to make API call
    */
-  public WebKeyServiceBetaDeleteWebKeyResponse webKeyServiceDeleteWebKey(String id, Map<String, String> additionalHeaders) throws ApiException {
+  private WebKeyServiceBetaDeleteWebKeyResponse webKeyServiceDeleteWebKey(String id, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     if (id == null) {
@@ -270,7 +270,7 @@ public class WebKeyServiceApi extends BaseApi {
    * @return WebKeyServiceBetaListWebKeysResponse
    * @throws ApiException if fails to make API call
    */
-  public WebKeyServiceBetaListWebKeysResponse webKeyServiceListWebKeys(Map<String, String> additionalHeaders) throws ApiException {
+  private WebKeyServiceBetaListWebKeysResponse webKeyServiceListWebKeys(Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     String localVarPath = "/v2beta/web_keys";

--- a/src/main/java/com/zitadel/model/ActionServiceBetaCondition.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaCondition.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   ActionServiceBetaCondition.JSON_PROPERTY_FUNCTION,
   ActionServiceBetaCondition.JSON_PROPERTY_EVENT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaCondition {
   public static final String JSON_PROPERTY_REQUEST = "request";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaCreateTargetResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaCreateTargetResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   ActionServiceBetaCreateTargetResponse.JSON_PROPERTY_CREATION_DATE,
   ActionServiceBetaCreateTargetResponse.JSON_PROPERTY_SIGNING_KEY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaCreateTargetResponse {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaDeleteTargetResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaDeleteTargetResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaDeleteTargetResponse.JSON_PROPERTY_DELETION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaDeleteTargetResponse {
   public static final String JSON_PROPERTY_DELETION_DATE = "deletionDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaEventExecution.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaEventExecution.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaEventExecution.JSON_PROPERTY_GROUP,
   ActionServiceBetaEventExecution.JSON_PROPERTY_ALL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaEventExecution {
   public static final String JSON_PROPERTY_EVENT = "event";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaExecution.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaExecution.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   ActionServiceBetaExecution.JSON_PROPERTY_CHANGE_DATE,
   ActionServiceBetaExecution.JSON_PROPERTY_TARGETS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaExecution {
   public static final String JSON_PROPERTY_CONDITION = "condition";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaFunctionExecution.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaFunctionExecution.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaFunctionExecution.JSON_PROPERTY_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaFunctionExecution {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaGetTargetResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaGetTargetResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaGetTargetResponse.JSON_PROPERTY_TARGET
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaGetTargetResponse {
   public static final String JSON_PROPERTY_TARGET = "target";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaInTargetIDsFilter.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaInTargetIDsFilter.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaInTargetIDsFilter.JSON_PROPERTY_TARGET_IDS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaInTargetIDsFilter {
   public static final String JSON_PROPERTY_TARGET_IDS = "targetIds";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionFunctionsResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionFunctionsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaListExecutionFunctionsResponse.JSON_PROPERTY_FUNCTIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaListExecutionFunctionsResponse {
   public static final String JSON_PROPERTY_FUNCTIONS = "functions";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionMethodsResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionMethodsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaListExecutionMethodsResponse.JSON_PROPERTY_METHODS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaListExecutionMethodsResponse {
   public static final String JSON_PROPERTY_METHODS = "methods";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionServicesResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionServicesResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaListExecutionServicesResponse.JSON_PROPERTY_SERVICES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaListExecutionServicesResponse {
   public static final String JSON_PROPERTY_SERVICES = "services";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionsResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaListExecutionsResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   ActionServiceBetaListExecutionsResponse.JSON_PROPERTY_PAGINATION,
   ActionServiceBetaListExecutionsResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaListExecutionsResponse {
   public static final String JSON_PROPERTY_PAGINATION = "pagination";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaListTargetsResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaListTargetsResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   ActionServiceBetaListTargetsResponse.JSON_PROPERTY_PAGINATION,
   ActionServiceBetaListTargetsResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaListTargetsResponse {
   public static final String JSON_PROPERTY_PAGINATION = "pagination";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaPaginationRequest.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaPaginationRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaPaginationRequest.JSON_PROPERTY_LIMIT,
   ActionServiceBetaPaginationRequest.JSON_PROPERTY_ASC
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaPaginationRequest {
   public static final String JSON_PROPERTY_OFFSET = "offset";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaPaginationResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaPaginationResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   ActionServiceBetaPaginationResponse.JSON_PROPERTY_TOTAL_RESULT,
   ActionServiceBetaPaginationResponse.JSON_PROPERTY_APPLIED_LIMIT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaPaginationResponse {
   public static final String JSON_PROPERTY_TOTAL_RESULT = "totalResult";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaRESTCall.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaRESTCall.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaRESTCall.JSON_PROPERTY_INTERRUPT_ON_ERROR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaRESTCall {
   public static final String JSON_PROPERTY_INTERRUPT_ON_ERROR = "interruptOnError";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaRESTWebhook.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaRESTWebhook.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaRESTWebhook.JSON_PROPERTY_INTERRUPT_ON_ERROR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaRESTWebhook {
   public static final String JSON_PROPERTY_INTERRUPT_ON_ERROR = "interruptOnError";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaRequestExecution.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaRequestExecution.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaRequestExecution.JSON_PROPERTY_SERVICE,
   ActionServiceBetaRequestExecution.JSON_PROPERTY_ALL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaRequestExecution {
   public static final String JSON_PROPERTY_METHOD = "method";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaResponseExecution.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaResponseExecution.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaResponseExecution.JSON_PROPERTY_SERVICE,
   ActionServiceBetaResponseExecution.JSON_PROPERTY_ALL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaResponseExecution {
   public static final String JSON_PROPERTY_METHOD = "method";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaSetExecutionResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaSetExecutionResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceBetaSetExecutionResponse.JSON_PROPERTY_SET_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaSetExecutionResponse {
   public static final String JSON_PROPERTY_SET_DATE = "setDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaTarget.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaTarget.java
@@ -44,7 +44,7 @@ import java.util.StringJoiner;
   ActionServiceBetaTarget.JSON_PROPERTY_ENDPOINT,
   ActionServiceBetaTarget.JSON_PROPERTY_SIGNING_KEY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaTarget {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaTargetNameFilter.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaTargetNameFilter.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaTargetNameFilter.JSON_PROPERTY_TARGET_NAME,
   ActionServiceBetaTargetNameFilter.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaTargetNameFilter {
   public static final String JSON_PROPERTY_TARGET_NAME = "targetName";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaTargetSearchFilter.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaTargetSearchFilter.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   ActionServiceBetaTargetSearchFilter.JSON_PROPERTY_TARGET_NAME_FILTER,
   ActionServiceBetaTargetSearchFilter.JSON_PROPERTY_IN_TARGET_IDS_FILTER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaTargetSearchFilter {
   public static final String JSON_PROPERTY_TARGET_NAME_FILTER = "targetNameFilter";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceBetaUpdateTargetResponse.java
+++ b/src/main/java/com/zitadel/model/ActionServiceBetaUpdateTargetResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   ActionServiceBetaUpdateTargetResponse.JSON_PROPERTY_CHANGE_DATE,
   ActionServiceBetaUpdateTargetResponse.JSON_PROPERTY_SIGNING_KEY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceBetaUpdateTargetResponse {
   public static final String JSON_PROPERTY_CHANGE_DATE = "changeDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceCreateTargetRequest.java
+++ b/src/main/java/com/zitadel/model/ActionServiceCreateTargetRequest.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   ActionServiceCreateTargetRequest.JSON_PROPERTY_TIMEOUT,
   ActionServiceCreateTargetRequest.JSON_PROPERTY_ENDPOINT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceCreateTargetRequest {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceListTargetsRequest.java
+++ b/src/main/java/com/zitadel/model/ActionServiceListTargetsRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   ActionServiceListTargetsRequest.JSON_PROPERTY_SORTING_COLUMN,
   ActionServiceListTargetsRequest.JSON_PROPERTY_FILTERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceListTargetsRequest {
   public static final String JSON_PROPERTY_PAGINATION = "pagination";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/ActionServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   ActionServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/ActionServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   ActionServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   ActionServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceSetExecutionRequest.java
+++ b/src/main/java/com/zitadel/model/ActionServiceSetExecutionRequest.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   ActionServiceSetExecutionRequest.JSON_PROPERTY_CONDITION,
   ActionServiceSetExecutionRequest.JSON_PROPERTY_TARGETS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceSetExecutionRequest {
   public static final String JSON_PROPERTY_CONDITION = "condition";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/ActionServiceUpdateTargetRequest.java
+++ b/src/main/java/com/zitadel/model/ActionServiceUpdateTargetRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   ActionServiceUpdateTargetRequest.JSON_PROPERTY_ENDPOINT,
   ActionServiceUpdateTargetRequest.JSON_PROPERTY_EXPIRATION_SIGNING_KEY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class ActionServiceUpdateTargetRequest {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceDetails.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   FeatureServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   FeatureServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceFeatureFlag.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceFeatureFlag.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   FeatureServiceFeatureFlag.JSON_PROPERTY_ENABLED,
   FeatureServiceFeatureFlag.JSON_PROPERTY_SOURCE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceFeatureFlag {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceGetInstanceFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceGetInstanceFeaturesResponse.java
@@ -50,7 +50,7 @@ import java.util.StringJoiner;
   FeatureServiceGetInstanceFeaturesResponse.JSON_PROPERTY_PERMISSION_CHECK_V2,
   FeatureServiceGetInstanceFeaturesResponse.JSON_PROPERTY_CONSOLE_USE_V2_USER_API
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceGetInstanceFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceGetOrganizationFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceGetOrganizationFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceGetOrganizationFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceGetOrganizationFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceGetSystemFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceGetSystemFeaturesResponse.java
@@ -47,7 +47,7 @@ import java.util.StringJoiner;
   FeatureServiceGetSystemFeaturesResponse.JSON_PROPERTY_LOGIN_V2,
   FeatureServiceGetSystemFeaturesResponse.JSON_PROPERTY_PERMISSION_CHECK_V2
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceGetSystemFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceGetUserFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceGetUserFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceGetUserFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceGetUserFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceImprovedPerformanceFeatureFlag.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceImprovedPerformanceFeatureFlag.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   FeatureServiceImprovedPerformanceFeatureFlag.JSON_PROPERTY_EXECUTION_PATHS,
   FeatureServiceImprovedPerformanceFeatureFlag.JSON_PROPERTY_SOURCE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceImprovedPerformanceFeatureFlag {
   public static final String JSON_PROPERTY_EXECUTION_PATHS = "executionPaths";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceLoginV2.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceLoginV2.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   FeatureServiceLoginV2.JSON_PROPERTY_REQUIRED,
   FeatureServiceLoginV2.JSON_PROPERTY_BASE_URI
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceLoginV2 {
   public static final String JSON_PROPERTY_REQUIRED = "required";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceLoginV2FeatureFlag.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceLoginV2FeatureFlag.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   FeatureServiceLoginV2FeatureFlag.JSON_PROPERTY_BASE_URI,
   FeatureServiceLoginV2FeatureFlag.JSON_PROPERTY_SOURCE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceLoginV2FeatureFlag {
   public static final String JSON_PROPERTY_REQUIRED = "required";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceResetInstanceFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceResetInstanceFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceResetInstanceFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceResetInstanceFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceResetOrganizationFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceResetOrganizationFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceResetOrganizationFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceResetOrganizationFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceResetSystemFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceResetSystemFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceResetSystemFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceResetSystemFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceResetUserFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceResetUserFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceResetUserFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceResetUserFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   FeatureServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   FeatureServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetInstanceFeaturesRequest.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetInstanceFeaturesRequest.java
@@ -50,7 +50,7 @@ import java.util.StringJoiner;
   FeatureServiceSetInstanceFeaturesRequest.JSON_PROPERTY_PERMISSION_CHECK_V2,
   FeatureServiceSetInstanceFeaturesRequest.JSON_PROPERTY_CONSOLE_USE_V2_USER_API
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetInstanceFeaturesRequest {
   public static final String JSON_PROPERTY_LOGIN_DEFAULT_ORG = "loginDefaultOrg";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetInstanceFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetInstanceFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceSetInstanceFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetInstanceFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetOrganizationFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetOrganizationFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceSetOrganizationFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetOrganizationFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetSystemFeaturesRequest.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetSystemFeaturesRequest.java
@@ -47,7 +47,7 @@ import java.util.StringJoiner;
   FeatureServiceSetSystemFeaturesRequest.JSON_PROPERTY_LOGIN_V2,
   FeatureServiceSetSystemFeaturesRequest.JSON_PROPERTY_PERMISSION_CHECK_V2
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetSystemFeaturesRequest {
   public static final String JSON_PROPERTY_LOGIN_DEFAULT_ORG = "loginDefaultOrg";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetSystemFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetSystemFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceSetSystemFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetSystemFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/FeatureServiceSetUserFeaturesResponse.java
+++ b/src/main/java/com/zitadel/model/FeatureServiceSetUserFeaturesResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   FeatureServiceSetUserFeaturesResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class FeatureServiceSetUserFeaturesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceAppleConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceAppleConfig.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceAppleConfig.JSON_PROPERTY_KEY_ID,
   IdentityProviderServiceAppleConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceAppleConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceAzureADConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceAzureADConfig.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceAzureADConfig.JSON_PROPERTY_EMAIL_VERIFIED,
   IdentityProviderServiceAzureADConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceAzureADConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceAzureADTenant.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceAzureADTenant.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceAzureADTenant.JSON_PROPERTY_TENANT_TYPE,
   IdentityProviderServiceAzureADTenant.JSON_PROPERTY_TENANT_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceAzureADTenant {
   public static final String JSON_PROPERTY_TENANT_TYPE = "tenantType";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceDetails.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   IdentityProviderServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGenericOIDCConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGenericOIDCConfig.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGenericOIDCConfig.JSON_PROPERTY_SCOPES,
   IdentityProviderServiceGenericOIDCConfig.JSON_PROPERTY_IS_ID_TOKEN_MAPPING
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGenericOIDCConfig {
   public static final String JSON_PROPERTY_ISSUER = "issuer";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGetIDPByIDResponse.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGetIDPByIDResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   IdentityProviderServiceGetIDPByIDResponse.JSON_PROPERTY_IDP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGetIDPByIDResponse {
   public static final String JSON_PROPERTY_IDP = "idp";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGitHubConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGitHubConfig.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGitHubConfig.JSON_PROPERTY_CLIENT_ID,
   IdentityProviderServiceGitHubConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGitHubConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGitHubEnterpriseServerConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGitHubEnterpriseServerConfig.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGitHubEnterpriseServerConfig.JSON_PROPERTY_USER_ENDPOINT,
   IdentityProviderServiceGitHubEnterpriseServerConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGitHubEnterpriseServerConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGitLabConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGitLabConfig.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGitLabConfig.JSON_PROPERTY_CLIENT_ID,
   IdentityProviderServiceGitLabConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGitLabConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGitLabSelfHostedConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGitLabSelfHostedConfig.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGitLabSelfHostedConfig.JSON_PROPERTY_CLIENT_ID,
   IdentityProviderServiceGitLabSelfHostedConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGitLabSelfHostedConfig {
   public static final String JSON_PROPERTY_ISSUER = "issuer";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceGoogleConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceGoogleConfig.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceGoogleConfig.JSON_PROPERTY_CLIENT_ID,
   IdentityProviderServiceGoogleConfig.JSON_PROPERTY_SCOPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceGoogleConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceIDP.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceIDP.java
@@ -41,7 +41,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceIDP.JSON_PROPERTY_TYPE,
   IdentityProviderServiceIDP.JSON_PROPERTY_CONFIG
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceIDP {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceIDPConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceIDPConfig.java
@@ -57,7 +57,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceIDPConfig.JSON_PROPERTY_APPLE,
   IdentityProviderServiceIDPConfig.JSON_PROPERTY_SAML
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceIDPConfig {
   public static final String JSON_PROPERTY_OPTIONS = "options";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceJWTConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceJWTConfig.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceJWTConfig.JSON_PROPERTY_KEYS_ENDPOINT,
   IdentityProviderServiceJWTConfig.JSON_PROPERTY_HEADER_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceJWTConfig {
   public static final String JSON_PROPERTY_JWT_ENDPOINT = "jwtEndpoint";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceLDAPAttributes.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceLDAPAttributes.java
@@ -45,7 +45,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceLDAPAttributes.JSON_PROPERTY_PROFILE_ATTRIBUTE,
   IdentityProviderServiceLDAPAttributes.JSON_PROPERTY_ROOT_CA
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceLDAPAttributes {
   public static final String JSON_PROPERTY_ID_ATTRIBUTE = "idAttribute";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceLDAPConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceLDAPConfig.java
@@ -45,7 +45,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceLDAPConfig.JSON_PROPERTY_ATTRIBUTES,
   IdentityProviderServiceLDAPConfig.JSON_PROPERTY_ROOT_CA
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceLDAPConfig {
   public static final String JSON_PROPERTY_SERVERS = "servers";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceOAuthConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceOAuthConfig.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceOAuthConfig.JSON_PROPERTY_SCOPES,
   IdentityProviderServiceOAuthConfig.JSON_PROPERTY_ID_ATTRIBUTE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceOAuthConfig {
   public static final String JSON_PROPERTY_CLIENT_ID = "clientId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceOptions.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceOptions.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceOptions.JSON_PROPERTY_IS_AUTO_UPDATE,
   IdentityProviderServiceOptions.JSON_PROPERTY_AUTO_LINKING
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceOptions {
   public static final String JSON_PROPERTY_IS_LINKING_ALLOWED = "isLinkingAllowed";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   IdentityProviderServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   IdentityProviderServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/IdentityProviderServiceSAMLConfig.java
+++ b/src/main/java/com/zitadel/model/IdentityProviderServiceSAMLConfig.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   IdentityProviderServiceSAMLConfig.JSON_PROPERTY_TRANSIENT_MAPPING_ATTRIBUTE_NAME,
   IdentityProviderServiceSAMLConfig.JSON_PROPERTY_FEDERATED_LOGOUT_ENABLED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class IdentityProviderServiceSAMLConfig {
   public static final String JSON_PROPERTY_METADATA_XML = "metadataXml";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceAuthRequest.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceAuthRequest.java
@@ -46,7 +46,7 @@ import java.util.StringJoiner;
   OIDCServiceAuthRequest.JSON_PROPERTY_MAX_AGE,
   OIDCServiceAuthRequest.JSON_PROPERTY_HINT_USER_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceAuthRequest {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceAuthorizationError.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceAuthorizationError.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   OIDCServiceAuthorizationError.JSON_PROPERTY_ERROR_DESCRIPTION,
   OIDCServiceAuthorizationError.JSON_PROPERTY_ERROR_URI
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceAuthorizationError {
   public static final String JSON_PROPERTY_ERROR = "error";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest.JSON_PROPERTY_SESSION,
   OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest.JSON_PROPERTY_DENY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceAuthorizeOrDenyDeviceAuthorizationRequest {
   public static final String JSON_PROPERTY_SESSION = "session";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceCreateCallbackRequest.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceCreateCallbackRequest.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   OIDCServiceCreateCallbackRequest.JSON_PROPERTY_SESSION,
   OIDCServiceCreateCallbackRequest.JSON_PROPERTY_ERROR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceCreateCallbackRequest {
   public static final String JSON_PROPERTY_SESSION = "session";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceCreateCallbackResponse.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceCreateCallbackResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OIDCServiceCreateCallbackResponse.JSON_PROPERTY_DETAILS,
   OIDCServiceCreateCallbackResponse.JSON_PROPERTY_CALLBACK_URL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceCreateCallbackResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceDetails.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   OIDCServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   OIDCServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceDeviceAuthorizationRequest.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceDeviceAuthorizationRequest.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   OIDCServiceDeviceAuthorizationRequest.JSON_PROPERTY_APP_NAME,
   OIDCServiceDeviceAuthorizationRequest.JSON_PROPERTY_PROJECT_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceDeviceAuthorizationRequest {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceGetAuthRequestResponse.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceGetAuthRequestResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OIDCServiceGetAuthRequestResponse.JSON_PROPERTY_AUTH_REQUEST
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceGetAuthRequestResponse {
   public static final String JSON_PROPERTY_AUTH_REQUEST = "authRequest";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceGetDeviceAuthorizationRequestResponse.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceGetDeviceAuthorizationRequestResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OIDCServiceGetDeviceAuthorizationRequestResponse.JSON_PROPERTY_DEVICE_AUTHORIZATION_REQUEST
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceGetDeviceAuthorizationRequestResponse {
   public static final String JSON_PROPERTY_DEVICE_AUTHORIZATION_REQUEST = "deviceAuthorizationRequest";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OIDCServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   OIDCServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   OIDCServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OIDCServiceSession.java
+++ b/src/main/java/com/zitadel/model/OIDCServiceSession.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   OIDCServiceSession.JSON_PROPERTY_SESSION_ID,
   OIDCServiceSession.JSON_PROPERTY_SESSION_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OIDCServiceSession {
   public static final String JSON_PROPERTY_SESSION_ID = "sessionId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceAddHumanUserRequest.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceAddHumanUserRequest.java
@@ -53,7 +53,7 @@ import java.util.StringJoiner;
   OrganizationServiceAddHumanUserRequest.JSON_PROPERTY_IDP_LINKS,
   OrganizationServiceAddHumanUserRequest.JSON_PROPERTY_TOTP_SECRET
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceAddHumanUserRequest {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationRequest.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationRequest.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   OrganizationServiceAddOrganizationRequest.JSON_PROPERTY_NAME,
   OrganizationServiceAddOrganizationRequest.JSON_PROPERTY_ADMINS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceAddOrganizationRequest {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationRequestAdmin.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationRequestAdmin.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   OrganizationServiceAddOrganizationRequestAdmin.JSON_PROPERTY_HUMAN,
   OrganizationServiceAddOrganizationRequestAdmin.JSON_PROPERTY_ROLES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceAddOrganizationRequestAdmin {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationResponse.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationResponse.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   OrganizationServiceAddOrganizationResponse.JSON_PROPERTY_ORGANIZATION_ID,
   OrganizationServiceAddOrganizationResponse.JSON_PROPERTY_CREATED_ADMINS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceAddOrganizationResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationResponseCreatedAdmin.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceAddOrganizationResponseCreatedAdmin.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OrganizationServiceAddOrganizationResponseCreatedAdmin.JSON_PROPERTY_EMAIL_CODE,
   OrganizationServiceAddOrganizationResponseCreatedAdmin.JSON_PROPERTY_PHONE_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceAddOrganizationResponseCreatedAdmin {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceDetails.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   OrganizationServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   OrganizationServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceHashedPassword.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceHashedPassword.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   OrganizationServiceHashedPassword.JSON_PROPERTY_HASH,
   OrganizationServiceHashedPassword.JSON_PROPERTY_CHANGE_REQUIRED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceHashedPassword {
   public static final String JSON_PROPERTY_HASH = "hash";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceIDPLink.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceIDPLink.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OrganizationServiceIDPLink.JSON_PROPERTY_USER_ID,
   OrganizationServiceIDPLink.JSON_PROPERTY_USER_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceIDPLink {
   public static final String JSON_PROPERTY_IDP_ID = "idpId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceListDetails.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceListDetails.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   OrganizationServiceListDetails.JSON_PROPERTY_PROCESSED_SEQUENCE,
   OrganizationServiceListDetails.JSON_PROPERTY_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceListDetails {
   public static final String JSON_PROPERTY_TOTAL_RESULT = "totalResult";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceListOrganizationsRequest.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceListOrganizationsRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   OrganizationServiceListOrganizationsRequest.JSON_PROPERTY_SORTING_COLUMN,
   OrganizationServiceListOrganizationsRequest.JSON_PROPERTY_QUERIES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceListOrganizationsRequest {
   public static final String JSON_PROPERTY_QUERY = "query";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceListOrganizationsResponse.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceListOrganizationsResponse.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   OrganizationServiceListOrganizationsResponse.JSON_PROPERTY_SORTING_COLUMN,
   OrganizationServiceListOrganizationsResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceListOrganizationsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceListQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceListQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OrganizationServiceListQuery.JSON_PROPERTY_LIMIT,
   OrganizationServiceListQuery.JSON_PROPERTY_ASC
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceListQuery {
   public static final String JSON_PROPERTY_OFFSET = "offset";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceOrganizationDomainQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceOrganizationDomainQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OrganizationServiceOrganizationDomainQuery.JSON_PROPERTY_DOMAIN,
   OrganizationServiceOrganizationDomainQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceOrganizationDomainQuery {
   public static final String JSON_PROPERTY_DOMAIN = "domain";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceOrganizationIDQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceOrganizationIDQuery.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OrganizationServiceOrganizationIDQuery.JSON_PROPERTY_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceOrganizationIDQuery {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceOrganizationNameQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceOrganizationNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   OrganizationServiceOrganizationNameQuery.JSON_PROPERTY_NAME,
   OrganizationServiceOrganizationNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceOrganizationNameQuery {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceOrganizationStateQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceOrganizationStateQuery.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OrganizationServiceOrganizationStateQuery.JSON_PROPERTY_STATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceOrganizationStateQuery {
   public static final String JSON_PROPERTY_STATE = "state";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServicePassword.java
+++ b/src/main/java/com/zitadel/model/OrganizationServicePassword.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   OrganizationServicePassword.JSON_PROPERTY_PASSWORD,
   OrganizationServicePassword.JSON_PROPERTY_CHANGE_REQUIRED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServicePassword {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OrganizationServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   OrganizationServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   OrganizationServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceSearchQuery.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSearchQuery.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   OrganizationServiceSearchQuery.JSON_PROPERTY_ID_QUERY,
   OrganizationServiceSearchQuery.JSON_PROPERTY_DEFAULT_QUERY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSearchQuery {
   public static final String JSON_PROPERTY_NAME_QUERY = "nameQuery";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceSendEmailVerificationCode.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSendEmailVerificationCode.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   OrganizationServiceSendEmailVerificationCode.JSON_PROPERTY_URL_TEMPLATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSendEmailVerificationCode {
   public static final String JSON_PROPERTY_URL_TEMPLATE = "urlTemplate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceSetHumanEmail.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSetHumanEmail.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   OrganizationServiceSetHumanEmail.JSON_PROPERTY_RETURN_CODE,
   OrganizationServiceSetHumanEmail.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSetHumanEmail {
   public static final String JSON_PROPERTY_EMAIL = "email";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceSetHumanPhone.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSetHumanPhone.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   OrganizationServiceSetHumanPhone.JSON_PROPERTY_RETURN_CODE,
   OrganizationServiceSetHumanPhone.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSetHumanPhone {
   public static final String JSON_PROPERTY_PHONE = "phone";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/OrganizationServiceSetHumanProfile.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSetHumanProfile.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   OrganizationServiceSetHumanProfile.JSON_PROPERTY_PREFERRED_LANGUAGE,
   OrganizationServiceSetHumanProfile.JSON_PROPERTY_GENDER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSetHumanProfile {
   public static final String JSON_PROPERTY_GIVEN_NAME = "givenName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/OrganizationServiceSetMetadataEntry.java
+++ b/src/main/java/com/zitadel/model/OrganizationServiceSetMetadataEntry.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   OrganizationServiceSetMetadataEntry.JSON_PROPERTY_KEY,
   OrganizationServiceSetMetadataEntry.JSON_PROPERTY_VALUE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class OrganizationServiceSetMetadataEntry {
   public static final String JSON_PROPERTY_KEY = "key";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/SAMLServiceAuthorizationError.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceAuthorizationError.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SAMLServiceAuthorizationError.JSON_PROPERTY_ERROR,
   SAMLServiceAuthorizationError.JSON_PROPERTY_ERROR_DESCRIPTION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceAuthorizationError {
   public static final String JSON_PROPERTY_ERROR = "error";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceCreateResponseRequest.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceCreateResponseRequest.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SAMLServiceCreateResponseRequest.JSON_PROPERTY_SESSION,
   SAMLServiceCreateResponseRequest.JSON_PROPERTY_ERROR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceCreateResponseRequest {
   public static final String JSON_PROPERTY_SESSION = "session";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceCreateResponseResponse.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceCreateResponseResponse.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SAMLServiceCreateResponseResponse.JSON_PROPERTY_REDIRECT,
   SAMLServiceCreateResponseResponse.JSON_PROPERTY_POST
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceCreateResponseResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceDetails.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SAMLServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   SAMLServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceGetSAMLRequestResponse.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceGetSAMLRequestResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SAMLServiceGetSAMLRequestResponse.JSON_PROPERTY_SAML_REQUEST
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceGetSAMLRequestResponse {
   public static final String JSON_PROPERTY_SAML_REQUEST = "samlRequest";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServicePostResponse.java
+++ b/src/main/java/com/zitadel/model/SAMLServicePostResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   SAMLServicePostResponse.JSON_PROPERTY_RELAY_STATE,
   SAMLServicePostResponse.JSON_PROPERTY_SAML_RESPONSE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServicePostResponse {
   public static final String JSON_PROPERTY_RELAY_STATE = "relayState";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SAMLServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SAMLServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   SAMLServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceSAMLRequest.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceSAMLRequest.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SAMLServiceSAMLRequest.JSON_PROPERTY_RELAY_STATE,
   SAMLServiceSAMLRequest.JSON_PROPERTY_BINDING
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceSAMLRequest {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SAMLServiceSession.java
+++ b/src/main/java/com/zitadel/model/SAMLServiceSession.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   SAMLServiceSession.JSON_PROPERTY_SESSION_ID,
   SAMLServiceSession.JSON_PROPERTY_SESSION_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SAMLServiceSession {
   public static final String JSON_PROPERTY_SESSION_ID = "sessionId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceChallenges.java
+++ b/src/main/java/com/zitadel/model/SessionServiceChallenges.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SessionServiceChallenges.JSON_PROPERTY_OTP_SMS,
   SessionServiceChallenges.JSON_PROPERTY_OTP_EMAIL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceChallenges {
   public static final String JSON_PROPERTY_WEB_AUTH_N = "webAuthN";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceChallengesWebAuthN.java
+++ b/src/main/java/com/zitadel/model/SessionServiceChallengesWebAuthN.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceChallengesWebAuthN.JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceChallengesWebAuthN {
   public static final String JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL_REQUEST_OPTIONS = "publicKeyCredentialRequestOptions";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckIDPIntent.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckIDPIntent.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   SessionServiceCheckIDPIntent.JSON_PROPERTY_IDP_INTENT_ID,
   SessionServiceCheckIDPIntent.JSON_PROPERTY_IDP_INTENT_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckIDPIntent {
   public static final String JSON_PROPERTY_IDP_INTENT_ID = "idpIntentId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckOTP.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckOTP.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceCheckOTP.JSON_PROPERTY_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckOTP {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckPassword.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckPassword.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceCheckPassword.JSON_PROPERTY_PASSWORD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckPassword {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckTOTP.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckTOTP.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceCheckTOTP.JSON_PROPERTY_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckTOTP {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckUser.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckUser.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   SessionServiceCheckUser.JSON_PROPERTY_USER_ID,
   SessionServiceCheckUser.JSON_PROPERTY_LOGIN_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckUser {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCheckWebAuthN.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCheckWebAuthN.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceCheckWebAuthN.JSON_PROPERTY_CREDENTIAL_ASSERTION_DATA
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCheckWebAuthN {
   public static final String JSON_PROPERTY_CREDENTIAL_ASSERTION_DATA = "credentialAssertionData";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/SessionServiceChecks.java
+++ b/src/main/java/com/zitadel/model/SessionServiceChecks.java
@@ -44,7 +44,7 @@ import java.util.StringJoiner;
   SessionServiceChecks.JSON_PROPERTY_OTP_SMS,
   SessionServiceChecks.JSON_PROPERTY_OTP_EMAIL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceChecks {
   public static final String JSON_PROPERTY_USER = "user";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCreateSessionRequest.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCreateSessionRequest.java
@@ -41,7 +41,7 @@ import java.util.StringJoiner;
   SessionServiceCreateSessionRequest.JSON_PROPERTY_USER_AGENT,
   SessionServiceCreateSessionRequest.JSON_PROPERTY_LIFETIME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCreateSessionRequest {
   public static final String JSON_PROPERTY_CHECKS = "checks";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCreateSessionResponse.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCreateSessionResponse.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SessionServiceCreateSessionResponse.JSON_PROPERTY_SESSION_TOKEN,
   SessionServiceCreateSessionResponse.JSON_PROPERTY_CHALLENGES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCreateSessionResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCreationDateQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCreationDateQuery.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SessionServiceCreationDateQuery.JSON_PROPERTY_CREATION_DATE,
   SessionServiceCreationDateQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCreationDateQuery {
   public static final String JSON_PROPERTY_CREATION_DATE = "creationDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceCreatorQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceCreatorQuery.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceCreatorQuery.JSON_PROPERTY_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceCreatorQuery {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceDeleteSessionRequest.java
+++ b/src/main/java/com/zitadel/model/SessionServiceDeleteSessionRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceDeleteSessionRequest.JSON_PROPERTY_SESSION_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceDeleteSessionRequest {
   public static final String JSON_PROPERTY_SESSION_TOKEN = "sessionToken";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceDeleteSessionResponse.java
+++ b/src/main/java/com/zitadel/model/SessionServiceDeleteSessionResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceDeleteSessionResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceDeleteSessionResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceDetails.java
+++ b/src/main/java/com/zitadel/model/SessionServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SessionServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   SessionServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceFactors.java
+++ b/src/main/java/com/zitadel/model/SessionServiceFactors.java
@@ -44,7 +44,7 @@ import java.util.StringJoiner;
   SessionServiceFactors.JSON_PROPERTY_OTP_SMS,
   SessionServiceFactors.JSON_PROPERTY_OTP_EMAIL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceFactors {
   public static final String JSON_PROPERTY_USER = "user";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceGetSessionResponse.java
+++ b/src/main/java/com/zitadel/model/SessionServiceGetSessionResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceGetSessionResponse.JSON_PROPERTY_SESSION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceGetSessionResponse {
   public static final String JSON_PROPERTY_SESSION = "session";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceIDsQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceIDsQuery.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceIDsQuery.JSON_PROPERTY_IDS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceIDsQuery {
   public static final String JSON_PROPERTY_IDS = "ids";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceIntentFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServiceIntentFactor.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceIntentFactor.JSON_PROPERTY_VERIFIED_AT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceIntentFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceListDetails.java
+++ b/src/main/java/com/zitadel/model/SessionServiceListDetails.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SessionServiceListDetails.JSON_PROPERTY_PROCESSED_SEQUENCE,
   SessionServiceListDetails.JSON_PROPERTY_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceListDetails {
   public static final String JSON_PROPERTY_TOTAL_RESULT = "totalResult";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceListQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceListQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SessionServiceListQuery.JSON_PROPERTY_LIMIT,
   SessionServiceListQuery.JSON_PROPERTY_ASC
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceListQuery {
   public static final String JSON_PROPERTY_OFFSET = "offset";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceListSessionsRequest.java
+++ b/src/main/java/com/zitadel/model/SessionServiceListSessionsRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   SessionServiceListSessionsRequest.JSON_PROPERTY_QUERIES,
   SessionServiceListSessionsRequest.JSON_PROPERTY_SORTING_COLUMN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceListSessionsRequest {
   public static final String JSON_PROPERTY_QUERY = "query";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceListSessionsResponse.java
+++ b/src/main/java/com/zitadel/model/SessionServiceListSessionsResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SessionServiceListSessionsResponse.JSON_PROPERTY_DETAILS,
   SessionServiceListSessionsResponse.JSON_PROPERTY_SESSIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceListSessionsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceOTPEmailSendCode.java
+++ b/src/main/java/com/zitadel/model/SessionServiceOTPEmailSendCode.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceOTPEmailSendCode.JSON_PROPERTY_URL_TEMPLATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceOTPEmailSendCode {
   public static final String JSON_PROPERTY_URL_TEMPLATE = "urlTemplate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceOTPFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServiceOTPFactor.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceOTPFactor.JSON_PROPERTY_VERIFIED_AT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceOTPFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServicePasswordFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServicePasswordFactor.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServicePasswordFactor.JSON_PROPERTY_VERIFIED_AT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServicePasswordFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/SessionServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceRequestChallenges.java
+++ b/src/main/java/com/zitadel/model/SessionServiceRequestChallenges.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SessionServiceRequestChallenges.JSON_PROPERTY_OTP_SMS,
   SessionServiceRequestChallenges.JSON_PROPERTY_OTP_EMAIL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceRequestChallenges {
   public static final String JSON_PROPERTY_WEB_AUTH_N = "webAuthN";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceRequestChallengesOTPEmail.java
+++ b/src/main/java/com/zitadel/model/SessionServiceRequestChallengesOTPEmail.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SessionServiceRequestChallengesOTPEmail.JSON_PROPERTY_SEND_CODE,
   SessionServiceRequestChallengesOTPEmail.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceRequestChallengesOTPEmail {
   public static final String JSON_PROPERTY_SEND_CODE = "sendCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceRequestChallengesOTPSMS.java
+++ b/src/main/java/com/zitadel/model/SessionServiceRequestChallengesOTPSMS.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceRequestChallengesOTPSMS.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceRequestChallengesOTPSMS {
   public static final String JSON_PROPERTY_RETURN_CODE = "returnCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceRequestChallengesWebAuthN.java
+++ b/src/main/java/com/zitadel/model/SessionServiceRequestChallengesWebAuthN.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SessionServiceRequestChallengesWebAuthN.JSON_PROPERTY_DOMAIN,
   SessionServiceRequestChallengesWebAuthN.JSON_PROPERTY_USER_VERIFICATION_REQUIREMENT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceRequestChallengesWebAuthN {
   public static final String JSON_PROPERTY_DOMAIN = "domain";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/SessionServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/SessionServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SessionServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   SessionServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceSearchQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceSearchQuery.java
@@ -41,7 +41,7 @@ import java.util.StringJoiner;
   SessionServiceSearchQuery.JSON_PROPERTY_CREATOR_QUERY,
   SessionServiceSearchQuery.JSON_PROPERTY_USER_AGENT_QUERY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceSearchQuery {
   public static final String JSON_PROPERTY_IDS_QUERY = "idsQuery";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceSession.java
+++ b/src/main/java/com/zitadel/model/SessionServiceSession.java
@@ -44,7 +44,7 @@ import java.util.StringJoiner;
   SessionServiceSession.JSON_PROPERTY_USER_AGENT,
   SessionServiceSession.JSON_PROPERTY_EXPIRATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceSession {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceSetSessionRequest.java
+++ b/src/main/java/com/zitadel/model/SessionServiceSetSessionRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   SessionServiceSetSessionRequest.JSON_PROPERTY_CHALLENGES,
   SessionServiceSetSessionRequest.JSON_PROPERTY_LIFETIME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceSetSessionRequest {
   public static final String JSON_PROPERTY_SESSION_TOKEN = "sessionToken";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceSetSessionResponse.java
+++ b/src/main/java/com/zitadel/model/SessionServiceSetSessionResponse.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SessionServiceSetSessionResponse.JSON_PROPERTY_SESSION_TOKEN,
   SessionServiceSetSessionResponse.JSON_PROPERTY_CHALLENGES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceSetSessionResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceTOTPFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServiceTOTPFactor.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceTOTPFactor.JSON_PROPERTY_VERIFIED_AT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceTOTPFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceUserAgent.java
+++ b/src/main/java/com/zitadel/model/SessionServiceUserAgent.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SessionServiceUserAgent.JSON_PROPERTY_DESCRIPTION,
   SessionServiceUserAgent.JSON_PROPERTY_HEADER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceUserAgent {
   public static final String JSON_PROPERTY_FINGERPRINT_ID = "fingerprintId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceUserAgentHeaderValues.java
+++ b/src/main/java/com/zitadel/model/SessionServiceUserAgentHeaderValues.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceUserAgentHeaderValues.JSON_PROPERTY_VALUES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceUserAgentHeaderValues {
   public static final String JSON_PROPERTY_VALUES = "values";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceUserAgentQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceUserAgentQuery.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceUserAgentQuery.JSON_PROPERTY_FINGERPRINT_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceUserAgentQuery {
   public static final String JSON_PROPERTY_FINGERPRINT_ID = "fingerprintId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceUserFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServiceUserFactor.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SessionServiceUserFactor.JSON_PROPERTY_DISPLAY_NAME,
   SessionServiceUserFactor.JSON_PROPERTY_ORGANIZATION_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceUserFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceUserIDQuery.java
+++ b/src/main/java/com/zitadel/model/SessionServiceUserIDQuery.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SessionServiceUserIDQuery.JSON_PROPERTY_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceUserIDQuery {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SessionServiceWebAuthNFactor.java
+++ b/src/main/java/com/zitadel/model/SessionServiceWebAuthNFactor.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SessionServiceWebAuthNFactor.JSON_PROPERTY_VERIFIED_AT,
   SessionServiceWebAuthNFactor.JSON_PROPERTY_USER_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SessionServiceWebAuthNFactor {
   public static final String JSON_PROPERTY_VERIFIED_AT = "verifiedAt";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceBrandingSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceBrandingSettings.java
@@ -41,7 +41,7 @@ import java.util.StringJoiner;
   SettingsServiceBrandingSettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE,
   SettingsServiceBrandingSettings.JSON_PROPERTY_THEME_MODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceBrandingSettings {
   public static final String JSON_PROPERTY_LIGHT_THEME = "lightTheme";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceDetails.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SettingsServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   SettingsServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceDomainSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceDomainSettings.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SettingsServiceDomainSettings.JSON_PROPERTY_SMTP_SENDER_ADDRESS_MATCHES_INSTANCE_DOMAIN,
   SettingsServiceDomainSettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceDomainSettings {
   public static final String JSON_PROPERTY_LOGIN_NAME_INCLUDES_DOMAIN = "loginNameIncludesDomain";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceEmbeddedIframeSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceEmbeddedIframeSettings.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   SettingsServiceEmbeddedIframeSettings.JSON_PROPERTY_ENABLED,
   SettingsServiceEmbeddedIframeSettings.JSON_PROPERTY_ALLOWED_ORIGINS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceEmbeddedIframeSettings {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetActiveIdentityProvidersResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetActiveIdentityProvidersResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SettingsServiceGetActiveIdentityProvidersResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetActiveIdentityProvidersResponse.JSON_PROPERTY_IDENTITY_PROVIDERS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetActiveIdentityProvidersResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetBrandingSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetBrandingSettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetBrandingSettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetBrandingSettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetBrandingSettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetDomainSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetDomainSettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetDomainSettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetDomainSettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetDomainSettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetGeneralSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetGeneralSettingsResponse.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SettingsServiceGetGeneralSettingsResponse.JSON_PROPERTY_DEFAULT_LANGUAGE,
   SettingsServiceGetGeneralSettingsResponse.JSON_PROPERTY_SUPPORTED_LANGUAGES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetGeneralSettingsResponse {
   public static final String JSON_PROPERTY_DEFAULT_ORG_ID = "defaultOrgId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetLegalAndSupportSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetLegalAndSupportSettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetLegalAndSupportSettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetLegalAndSupportSettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetLegalAndSupportSettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetLockoutSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetLockoutSettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetLockoutSettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetLockoutSettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetLockoutSettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetLoginSettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetLoginSettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetLoginSettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetLoginSettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetLoginSettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetPasswordComplexitySettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetPasswordComplexitySettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetPasswordComplexitySettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetPasswordComplexitySettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetPasswordComplexitySettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetPasswordExpirySettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetPasswordExpirySettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetPasswordExpirySettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetPasswordExpirySettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetPasswordExpirySettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceGetSecuritySettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceGetSecuritySettingsResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceGetSecuritySettingsResponse.JSON_PROPERTY_DETAILS,
   SettingsServiceGetSecuritySettingsResponse.JSON_PROPERTY_SETTINGS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceGetSecuritySettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceIdentityProvider.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceIdentityProvider.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SettingsServiceIdentityProvider.JSON_PROPERTY_TYPE,
   SettingsServiceIdentityProvider.JSON_PROPERTY_OPTIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceIdentityProvider {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceLegalAndSupportSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceLegalAndSupportSettings.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   SettingsServiceLegalAndSupportSettings.JSON_PROPERTY_CUSTOM_LINK,
   SettingsServiceLegalAndSupportSettings.JSON_PROPERTY_CUSTOM_LINK_TEXT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceLegalAndSupportSettings {
   public static final String JSON_PROPERTY_TOS_LINK = "tosLink";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceListDetails.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceListDetails.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceListDetails.JSON_PROPERTY_PROCESSED_SEQUENCE,
   SettingsServiceListDetails.JSON_PROPERTY_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceListDetails {
   public static final String JSON_PROPERTY_TOTAL_RESULT = "totalResult";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceLockoutSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceLockoutSettings.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServiceLockoutSettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE,
   SettingsServiceLockoutSettings.JSON_PROPERTY_MAX_OTP_ATTEMPTS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceLockoutSettings {
   public static final String JSON_PROPERTY_MAX_PASSWORD_ATTEMPTS = "maxPasswordAttempts";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceLoginSettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceLoginSettings.java
@@ -58,7 +58,7 @@ import java.util.StringJoiner;
   SettingsServiceLoginSettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE,
   SettingsServiceLoginSettings.JSON_PROPERTY_FORCE_MFA_LOCAL_ONLY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceLoginSettings {
   public static final String JSON_PROPERTY_ALLOW_USERNAME_PASSWORD = "allowUsernamePassword";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceOptions.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceOptions.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SettingsServiceOptions.JSON_PROPERTY_IS_AUTO_UPDATE,
   SettingsServiceOptions.JSON_PROPERTY_AUTO_LINKING
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceOptions {
   public static final String JSON_PROPERTY_IS_LINKING_ALLOWED = "isLinkingAllowed";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServicePasswordComplexitySettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServicePasswordComplexitySettings.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SettingsServicePasswordComplexitySettings.JSON_PROPERTY_REQUIRES_SYMBOL,
   SettingsServicePasswordComplexitySettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServicePasswordComplexitySettings {
   public static final String JSON_PROPERTY_MIN_LENGTH = "minLength";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServicePasswordExpirySettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServicePasswordExpirySettings.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   SettingsServicePasswordExpirySettings.JSON_PROPERTY_EXPIRE_WARN_DAYS,
   SettingsServicePasswordExpirySettings.JSON_PROPERTY_RESOURCE_OWNER_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServicePasswordExpirySettings {
   public static final String JSON_PROPERTY_MAX_AGE_DAYS = "maxAgeDays";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SettingsServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   SettingsServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   SettingsServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceSecuritySettings.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceSecuritySettings.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SettingsServiceSecuritySettings.JSON_PROPERTY_EMBEDDED_IFRAME,
   SettingsServiceSecuritySettings.JSON_PROPERTY_ENABLE_IMPERSONATION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceSecuritySettings {
   public static final String JSON_PROPERTY_EMBEDDED_IFRAME = "embeddedIframe";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceSetSecuritySettingsRequest.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceSetSecuritySettingsRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   SettingsServiceSetSecuritySettingsRequest.JSON_PROPERTY_EMBEDDED_IFRAME,
   SettingsServiceSetSecuritySettingsRequest.JSON_PROPERTY_ENABLE_IMPERSONATION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceSetSecuritySettingsRequest {
   public static final String JSON_PROPERTY_EMBEDDED_IFRAME = "embeddedIframe";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceSetSecuritySettingsResponse.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceSetSecuritySettingsResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   SettingsServiceSetSecuritySettingsResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceSetSecuritySettingsResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/SettingsServiceTheme.java
+++ b/src/main/java/com/zitadel/model/SettingsServiceTheme.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   SettingsServiceTheme.JSON_PROPERTY_LOGO_URL,
   SettingsServiceTheme.JSON_PROPERTY_ICON_URL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class SettingsServiceTheme {
   public static final String JSON_PROPERTY_PRIMARY_COLOR = "primaryColor";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddHumanUserRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddHumanUserRequest.java
@@ -53,7 +53,7 @@ import java.util.StringJoiner;
   UserServiceAddHumanUserRequest.JSON_PROPERTY_IDP_LINKS,
   UserServiceAddHumanUserRequest.JSON_PROPERTY_TOTP_SECRET
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddHumanUserRequest {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddHumanUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddHumanUserResponse.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceAddHumanUserResponse.JSON_PROPERTY_EMAIL_CODE,
   UserServiceAddHumanUserResponse.JSON_PROPERTY_PHONE_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddHumanUserResponse {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddIDPLinkRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddIDPLinkRequest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceAddIDPLinkRequest.JSON_PROPERTY_IDP_LINK
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddIDPLinkRequest {
   public static final String JSON_PROPERTY_IDP_LINK = "idpLink";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddIDPLinkResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddIDPLinkResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceAddIDPLinkResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddIDPLinkResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddOTPEmailResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddOTPEmailResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceAddOTPEmailResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddOTPEmailResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAddOTPSMSResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceAddOTPSMSResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceAddOTPSMSResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAddOTPSMSResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAndQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceAndQuery.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceAndQuery.JSON_PROPERTY_QUERIES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAndQuery {
   public static final String JSON_PROPERTY_QUERIES = "queries";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAuthFactor.java
+++ b/src/main/java/com/zitadel/model/UserServiceAuthFactor.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceAuthFactor.JSON_PROPERTY_OTP_SMS,
   UserServiceAuthFactor.JSON_PROPERTY_OTP_EMAIL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAuthFactor {
   public static final String JSON_PROPERTY_STATE = "state";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceAuthFactorU2F.java
+++ b/src/main/java/com/zitadel/model/UserServiceAuthFactorU2F.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceAuthFactorU2F.JSON_PROPERTY_ID,
   UserServiceAuthFactorU2F.JSON_PROPERTY_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceAuthFactorU2F {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceCreateInviteCodeRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceCreateInviteCodeRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceCreateInviteCodeRequest.JSON_PROPERTY_SEND_CODE,
   UserServiceCreateInviteCodeRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceCreateInviteCodeRequest {
   public static final String JSON_PROPERTY_SEND_CODE = "sendCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceCreateInviteCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceCreateInviteCodeResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceCreateInviteCodeResponse.JSON_PROPERTY_DETAILS,
   UserServiceCreateInviteCodeResponse.JSON_PROPERTY_INVITE_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceCreateInviteCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceCreatePasskeyRegistrationLinkRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceCreatePasskeyRegistrationLinkRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceCreatePasskeyRegistrationLinkRequest.JSON_PROPERTY_SEND_LINK,
   UserServiceCreatePasskeyRegistrationLinkRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceCreatePasskeyRegistrationLinkRequest {
   public static final String JSON_PROPERTY_SEND_LINK = "sendLink";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceCreatePasskeyRegistrationLinkResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceCreatePasskeyRegistrationLinkResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceCreatePasskeyRegistrationLinkResponse.JSON_PROPERTY_DETAILS,
   UserServiceCreatePasskeyRegistrationLinkResponse.JSON_PROPERTY_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceCreatePasskeyRegistrationLinkResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceDeactivateUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceDeactivateUserResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceDeactivateUserResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceDeactivateUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceDeleteUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceDeleteUserResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceDeleteUserResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceDeleteUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceDetails.java
+++ b/src/main/java/com/zitadel/model/UserServiceDetails.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceDetails.JSON_PROPERTY_RESOURCE_OWNER,
   UserServiceDetails.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceDetails {
   public static final String JSON_PROPERTY_SEQUENCE = "sequence";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceDisplayNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceDisplayNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceDisplayNameQuery.JSON_PROPERTY_DISPLAY_NAME,
   UserServiceDisplayNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceDisplayNameQuery {
   public static final String JSON_PROPERTY_DISPLAY_NAME = "displayName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceEmailQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceEmailQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceEmailQuery.JSON_PROPERTY_EMAIL_ADDRESS,
   UserServiceEmailQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceEmailQuery {
   public static final String JSON_PROPERTY_EMAIL_ADDRESS = "emailAddress";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceFirstNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceFirstNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceFirstNameQuery.JSON_PROPERTY_FIRST_NAME,
   UserServiceFirstNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceFirstNameQuery {
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceGetUserByIDResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceGetUserByIDResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceGetUserByIDResponse.JSON_PROPERTY_DETAILS,
   UserServiceGetUserByIDResponse.JSON_PROPERTY_USER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceGetUserByIDResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceHashedPassword.java
+++ b/src/main/java/com/zitadel/model/UserServiceHashedPassword.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceHashedPassword.JSON_PROPERTY_HASH,
   UserServiceHashedPassword.JSON_PROPERTY_CHANGE_REQUIRED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHashedPassword {
   public static final String JSON_PROPERTY_HASH = "hash";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceHumanEmail.java
+++ b/src/main/java/com/zitadel/model/UserServiceHumanEmail.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceHumanEmail.JSON_PROPERTY_EMAIL,
   UserServiceHumanEmail.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHumanEmail {
   public static final String JSON_PROPERTY_EMAIL = "email";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceHumanMFAInitSkippedResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceHumanMFAInitSkippedResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceHumanMFAInitSkippedResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHumanMFAInitSkippedResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceHumanPhone.java
+++ b/src/main/java/com/zitadel/model/UserServiceHumanPhone.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceHumanPhone.JSON_PROPERTY_PHONE,
   UserServiceHumanPhone.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHumanPhone {
   public static final String JSON_PROPERTY_PHONE = "phone";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceHumanProfile.java
+++ b/src/main/java/com/zitadel/model/UserServiceHumanProfile.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   UserServiceHumanProfile.JSON_PROPERTY_GENDER,
   UserServiceHumanProfile.JSON_PROPERTY_AVATAR_URL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHumanProfile {
   public static final String JSON_PROPERTY_GIVEN_NAME = "givenName";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceHumanUser.java
+++ b/src/main/java/com/zitadel/model/UserServiceHumanUser.java
@@ -50,7 +50,7 @@ import java.util.StringJoiner;
   UserServiceHumanUser.JSON_PROPERTY_PASSWORD_CHANGED,
   UserServiceHumanUser.JSON_PROPERTY_MFA_INIT_SKIPPED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceHumanUser {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPInformation.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPInformation.java
@@ -41,7 +41,7 @@ import java.util.StringJoiner;
   UserServiceIDPInformation.JSON_PROPERTY_USER_NAME,
   UserServiceIDPInformation.JSON_PROPERTY_RAW_INFORMATION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPInformation {
   public static final String JSON_PROPERTY_OAUTH = "oauth";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPIntent.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPIntent.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceIDPIntent.JSON_PROPERTY_IDP_INTENT_TOKEN,
   UserServiceIDPIntent.JSON_PROPERTY_USER_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPIntent {
   public static final String JSON_PROPERTY_IDP_INTENT_ID = "idpIntentId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPLDAPAccessInformation.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPLDAPAccessInformation.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceIDPLDAPAccessInformation.JSON_PROPERTY_ATTRIBUTES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPLDAPAccessInformation {
   public static final String JSON_PROPERTY_ATTRIBUTES = "attributes";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPLink.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPLink.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceIDPLink.JSON_PROPERTY_USER_ID,
   UserServiceIDPLink.JSON_PROPERTY_USER_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPLink {
   public static final String JSON_PROPERTY_IDP_ID = "idpId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPOAuthAccessInformation.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPOAuthAccessInformation.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceIDPOAuthAccessInformation.JSON_PROPERTY_ACCESS_TOKEN,
   UserServiceIDPOAuthAccessInformation.JSON_PROPERTY_ID_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPOAuthAccessInformation {
   public static final String JSON_PROPERTY_ACCESS_TOKEN = "accessToken";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceIDPSAMLAccessInformation.java
+++ b/src/main/java/com/zitadel/model/UserServiceIDPSAMLAccessInformation.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceIDPSAMLAccessInformation.JSON_PROPERTY_ASSERTION
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceIDPSAMLAccessInformation {
   public static final String JSON_PROPERTY_ASSERTION = "assertion";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceInUserEmailsQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceInUserEmailsQuery.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceInUserEmailsQuery.JSON_PROPERTY_USER_EMAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceInUserEmailsQuery {
   public static final String JSON_PROPERTY_USER_EMAILS = "userEmails";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceInUserIDQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceInUserIDQuery.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceInUserIDQuery.JSON_PROPERTY_USER_IDS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceInUserIDQuery {
   public static final String JSON_PROPERTY_USER_IDS = "userIds";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceLDAPCredentials.java
+++ b/src/main/java/com/zitadel/model/UserServiceLDAPCredentials.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceLDAPCredentials.JSON_PROPERTY_USERNAME,
   UserServiceLDAPCredentials.JSON_PROPERTY_PASSWORD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceLDAPCredentials {
   public static final String JSON_PROPERTY_USERNAME = "username";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceLastNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceLastNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceLastNameQuery.JSON_PROPERTY_LAST_NAME,
   UserServiceLastNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceLastNameQuery {
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceListAuthenticationFactorsResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceListAuthenticationFactorsResponse.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceListAuthenticationFactorsResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListAuthenticationFactorsResponse {
   public static final String JSON_PROPERTY_RESULT = "result";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListAuthenticationMethodTypesResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceListAuthenticationMethodTypesResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceListAuthenticationMethodTypesResponse.JSON_PROPERTY_DETAILS,
   UserServiceListAuthenticationMethodTypesResponse.JSON_PROPERTY_AUTH_METHOD_TYPES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListAuthenticationMethodTypesResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListDetails.java
+++ b/src/main/java/com/zitadel/model/UserServiceListDetails.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceListDetails.JSON_PROPERTY_PROCESSED_SEQUENCE,
   UserServiceListDetails.JSON_PROPERTY_TIMESTAMP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListDetails {
   public static final String JSON_PROPERTY_TOTAL_RESULT = "totalResult";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListIDPLinksRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceListIDPLinksRequest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceListIDPLinksRequest.JSON_PROPERTY_QUERY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListIDPLinksRequest {
   public static final String JSON_PROPERTY_QUERY = "query";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListIDPLinksResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceListIDPLinksResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceListIDPLinksResponse.JSON_PROPERTY_DETAILS,
   UserServiceListIDPLinksResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListIDPLinksResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListPasskeysResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceListPasskeysResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceListPasskeysResponse.JSON_PROPERTY_DETAILS,
   UserServiceListPasskeysResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListPasskeysResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceListQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceListQuery.JSON_PROPERTY_LIMIT,
   UserServiceListQuery.JSON_PROPERTY_ASC
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListQuery {
   public static final String JSON_PROPERTY_OFFSET = "offset";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListUsersRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceListUsersRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   UserServiceListUsersRequest.JSON_PROPERTY_SORTING_COLUMN,
   UserServiceListUsersRequest.JSON_PROPERTY_QUERIES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListUsersRequest {
   public static final String JSON_PROPERTY_QUERY = "query";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceListUsersResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceListUsersResponse.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   UserServiceListUsersResponse.JSON_PROPERTY_SORTING_COLUMN,
   UserServiceListUsersResponse.JSON_PROPERTY_RESULT
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceListUsersResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceLockUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceLockUserResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceLockUserResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceLockUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceLoginNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceLoginNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceLoginNameQuery.JSON_PROPERTY_LOGIN_NAME,
   UserServiceLoginNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceLoginNameQuery {
   public static final String JSON_PROPERTY_LOGIN_NAME = "loginName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceMachineUser.java
+++ b/src/main/java/com/zitadel/model/UserServiceMachineUser.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceMachineUser.JSON_PROPERTY_HAS_SECRET,
   UserServiceMachineUser.JSON_PROPERTY_ACCESS_TOKEN_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceMachineUser {
   public static final String JSON_PROPERTY_NAME = "name";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceNickNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceNickNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceNickNameQuery.JSON_PROPERTY_NICK_NAME,
   UserServiceNickNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceNickNameQuery {
   public static final String JSON_PROPERTY_NICK_NAME = "nickName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceNotQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceNotQuery.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceNotQuery.JSON_PROPERTY_QUERY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceNotQuery {
   public static final String JSON_PROPERTY_QUERY = "query";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceOrQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceOrQuery.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceOrQuery.JSON_PROPERTY_QUERIES
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceOrQuery {
   public static final String JSON_PROPERTY_QUERIES = "queries";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceOrganization.java
+++ b/src/main/java/com/zitadel/model/UserServiceOrganization.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceOrganization.JSON_PROPERTY_ORG_ID,
   UserServiceOrganization.JSON_PROPERTY_ORG_DOMAIN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceOrganization {
   public static final String JSON_PROPERTY_ORG_ID = "orgId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceOrganizationIdQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceOrganizationIdQuery.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceOrganizationIdQuery.JSON_PROPERTY_ORGANIZATION_ID
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceOrganizationIdQuery {
   public static final String JSON_PROPERTY_ORGANIZATION_ID = "organizationId";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServicePasskey.java
+++ b/src/main/java/com/zitadel/model/UserServicePasskey.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServicePasskey.JSON_PROPERTY_STATE,
   UserServicePasskey.JSON_PROPERTY_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePasskey {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServicePasskeyRegistrationCode.java
+++ b/src/main/java/com/zitadel/model/UserServicePasskeyRegistrationCode.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServicePasskeyRegistrationCode.JSON_PROPERTY_ID,
   UserServicePasskeyRegistrationCode.JSON_PROPERTY_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePasskeyRegistrationCode {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServicePassword.java
+++ b/src/main/java/com/zitadel/model/UserServicePassword.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServicePassword.JSON_PROPERTY_PASSWORD,
   UserServicePassword.JSON_PROPERTY_CHANGE_REQUIRED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePassword {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServicePasswordResetRequest.java
+++ b/src/main/java/com/zitadel/model/UserServicePasswordResetRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServicePasswordResetRequest.JSON_PROPERTY_SEND_LINK,
   UserServicePasswordResetRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePasswordResetRequest {
   public static final String JSON_PROPERTY_SEND_LINK = "sendLink";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServicePasswordResetResponse.java
+++ b/src/main/java/com/zitadel/model/UserServicePasswordResetResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServicePasswordResetResponse.JSON_PROPERTY_DETAILS,
   UserServicePasswordResetResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePasswordResetResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServicePhoneQuery.java
+++ b/src/main/java/com/zitadel/model/UserServicePhoneQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServicePhoneQuery.JSON_PROPERTY_NUMBER,
   UserServicePhoneQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServicePhoneQuery {
   public static final String JSON_PROPERTY_NUMBER = "number";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/UserServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceReactivateUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceReactivateUserResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceReactivateUserResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceReactivateUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRedirectURLs.java
+++ b/src/main/java/com/zitadel/model/UserServiceRedirectURLs.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceRedirectURLs.JSON_PROPERTY_SUCCESS_URL,
   UserServiceRedirectURLs.JSON_PROPERTY_FAILURE_URL
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRedirectURLs {
   public static final String JSON_PROPERTY_SUCCESS_URL = "successUrl";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRegisterPasskeyRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceRegisterPasskeyRequest.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceRegisterPasskeyRequest.JSON_PROPERTY_AUTHENTICATOR,
   UserServiceRegisterPasskeyRequest.JSON_PROPERTY_DOMAIN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRegisterPasskeyRequest {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRegisterPasskeyResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRegisterPasskeyResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceRegisterPasskeyResponse.JSON_PROPERTY_PASSKEY_ID,
   UserServiceRegisterPasskeyResponse.JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRegisterPasskeyResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRegisterTOTPResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRegisterTOTPResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceRegisterTOTPResponse.JSON_PROPERTY_URI,
   UserServiceRegisterTOTPResponse.JSON_PROPERTY_SECRET
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRegisterTOTPResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRegisterU2FRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceRegisterU2FRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRegisterU2FRequest.JSON_PROPERTY_DOMAIN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRegisterU2FRequest {
   public static final String JSON_PROPERTY_DOMAIN = "domain";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRegisterU2FResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRegisterU2FResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceRegisterU2FResponse.JSON_PROPERTY_U2F_ID,
   UserServiceRegisterU2FResponse.JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL_CREATION_OPTIONS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRegisterU2FResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemoveIDPLinkResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemoveIDPLinkResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemoveIDPLinkResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemoveIDPLinkResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemoveOTPEmailResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemoveOTPEmailResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemoveOTPEmailResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemoveOTPEmailResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemoveOTPSMSResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemoveOTPSMSResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemoveOTPSMSResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemoveOTPSMSResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemovePasskeyResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemovePasskeyResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemovePasskeyResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemovePasskeyResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemovePhoneResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemovePhoneResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemovePhoneResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemovePhoneResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemoveTOTPResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemoveTOTPResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemoveTOTPResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemoveTOTPResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRemoveU2FResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRemoveU2FResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRemoveU2FResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRemoveU2FResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceResendEmailCodeRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceResendEmailCodeRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceResendEmailCodeRequest.JSON_PROPERTY_SEND_CODE,
   UserServiceResendEmailCodeRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceResendEmailCodeRequest {
   public static final String JSON_PROPERTY_SEND_CODE = "sendCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceResendEmailCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceResendEmailCodeResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceResendEmailCodeResponse.JSON_PROPERTY_DETAILS,
   UserServiceResendEmailCodeResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceResendEmailCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceResendInviteCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceResendInviteCodeResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceResendInviteCodeResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceResendInviteCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceResendPhoneCodeRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceResendPhoneCodeRequest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceResendPhoneCodeRequest.JSON_PROPERTY_SEND_CODE,
   UserServiceResendPhoneCodeRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceResendPhoneCodeRequest {
   public static final String JSON_PROPERTY_SEND_CODE = "sendCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceResendPhoneCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceResendPhoneCodeResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceResendPhoneCodeResponse.JSON_PROPERTY_DETAILS,
   UserServiceResendPhoneCodeResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceResendPhoneCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRetrieveIdentityProviderIntentRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceRetrieveIdentityProviderIntentRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceRetrieveIdentityProviderIntentRequest.JSON_PROPERTY_IDP_INTENT_TOKEN
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRetrieveIdentityProviderIntentRequest {
   public static final String JSON_PROPERTY_IDP_INTENT_TOKEN = "idpIntentToken";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRetrieveIdentityProviderIntentResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceRetrieveIdentityProviderIntentResponse.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceRetrieveIdentityProviderIntentResponse.JSON_PROPERTY_USER_ID,
   UserServiceRetrieveIdentityProviderIntentResponse.JSON_PROPERTY_ADD_HUMAN_USER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRetrieveIdentityProviderIntentResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/UserServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   UserServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSearchQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceSearchQuery.java
@@ -63,7 +63,7 @@ import java.util.StringJoiner;
   UserServiceSearchQuery.JSON_PROPERTY_ORGANIZATION_ID_QUERY,
   UserServiceSearchQuery.JSON_PROPERTY_PHONE_QUERY
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSearchQuery {
   public static final String JSON_PROPERTY_USER_NAME_QUERY = "userNameQuery";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendEmailCodeRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendEmailCodeRequest.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceSendEmailCodeRequest.JSON_PROPERTY_SEND_CODE,
   UserServiceSendEmailCodeRequest.JSON_PROPERTY_RETURN_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendEmailCodeRequest {
   public static final String JSON_PROPERTY_SEND_CODE = "sendCode";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendEmailCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendEmailCodeResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceSendEmailCodeResponse.JSON_PROPERTY_DETAILS,
   UserServiceSendEmailCodeResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendEmailCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendEmailVerificationCode.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendEmailVerificationCode.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceSendEmailVerificationCode.JSON_PROPERTY_URL_TEMPLATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendEmailVerificationCode {
   public static final String JSON_PROPERTY_URL_TEMPLATE = "urlTemplate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendInviteCode.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendInviteCode.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceSendInviteCode.JSON_PROPERTY_URL_TEMPLATE,
   UserServiceSendInviteCode.JSON_PROPERTY_APPLICATION_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendInviteCode {
   public static final String JSON_PROPERTY_URL_TEMPLATE = "urlTemplate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendPasskeyRegistrationLink.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendPasskeyRegistrationLink.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceSendPasskeyRegistrationLink.JSON_PROPERTY_URL_TEMPLATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendPasskeyRegistrationLink {
   public static final String JSON_PROPERTY_URL_TEMPLATE = "urlTemplate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSendPasswordResetLink.java
+++ b/src/main/java/com/zitadel/model/UserServiceSendPasswordResetLink.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceSendPasswordResetLink.JSON_PROPERTY_NOTIFICATION_TYPE,
   UserServiceSendPasswordResetLink.JSON_PROPERTY_URL_TEMPLATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSendPasswordResetLink {
   public static final String JSON_PROPERTY_NOTIFICATION_TYPE = "notificationType";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetEmailRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetEmailRequest.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceSetEmailRequest.JSON_PROPERTY_RETURN_CODE,
   UserServiceSetEmailRequest.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetEmailRequest {
   public static final String JSON_PROPERTY_EMAIL = "email";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceSetEmailResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetEmailResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceSetEmailResponse.JSON_PROPERTY_DETAILS,
   UserServiceSetEmailResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetEmailResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetHumanEmail.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetHumanEmail.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceSetHumanEmail.JSON_PROPERTY_RETURN_CODE,
   UserServiceSetHumanEmail.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetHumanEmail {
   public static final String JSON_PROPERTY_EMAIL = "email";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceSetHumanPhone.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetHumanPhone.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceSetHumanPhone.JSON_PROPERTY_RETURN_CODE,
   UserServiceSetHumanPhone.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetHumanPhone {
   public static final String JSON_PROPERTY_PHONE = "phone";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetHumanProfile.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetHumanProfile.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   UserServiceSetHumanProfile.JSON_PROPERTY_PREFERRED_LANGUAGE,
   UserServiceSetHumanProfile.JSON_PROPERTY_GENDER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetHumanProfile {
   public static final String JSON_PROPERTY_GIVEN_NAME = "givenName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceSetMetadataEntry.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetMetadataEntry.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceSetMetadataEntry.JSON_PROPERTY_KEY,
   UserServiceSetMetadataEntry.JSON_PROPERTY_VALUE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetMetadataEntry {
   public static final String JSON_PROPERTY_KEY = "key";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceSetPassword.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetPassword.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   UserServiceSetPassword.JSON_PROPERTY_CURRENT_PASSWORD,
   UserServiceSetPassword.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetPassword {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetPasswordRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetPasswordRequest.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceSetPasswordRequest.JSON_PROPERTY_CURRENT_PASSWORD,
   UserServiceSetPasswordRequest.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetPasswordRequest {
   public static final String JSON_PROPERTY_NEW_PASSWORD = "newPassword";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetPasswordResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetPasswordResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceSetPasswordResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetPasswordResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceSetPhoneRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetPhoneRequest.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceSetPhoneRequest.JSON_PROPERTY_RETURN_CODE,
   UserServiceSetPhoneRequest.JSON_PROPERTY_IS_VERIFIED
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetPhoneRequest {
   public static final String JSON_PROPERTY_PHONE = "phone";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceSetPhoneResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceSetPhoneResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceSetPhoneResponse.JSON_PROPERTY_DETAILS,
   UserServiceSetPhoneResponse.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceSetPhoneResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceStartIdentityProviderIntentRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceStartIdentityProviderIntentRequest.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   UserServiceStartIdentityProviderIntentRequest.JSON_PROPERTY_URLS,
   UserServiceStartIdentityProviderIntentRequest.JSON_PROPERTY_LDAP
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceStartIdentityProviderIntentRequest {
   public static final String JSON_PROPERTY_IDP_ID = "idpId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceStartIdentityProviderIntentResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceStartIdentityProviderIntentResponse.java
@@ -37,7 +37,7 @@ import java.util.StringJoiner;
   UserServiceStartIdentityProviderIntentResponse.JSON_PROPERTY_IDP_INTENT,
   UserServiceStartIdentityProviderIntentResponse.JSON_PROPERTY_POST_FORM
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceStartIdentityProviderIntentResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceStateQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceStateQuery.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceStateQuery.JSON_PROPERTY_STATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceStateQuery {
   public static final String JSON_PROPERTY_STATE = "state";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceTypeQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceTypeQuery.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceTypeQuery.JSON_PROPERTY_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceTypeQuery {
   public static final String JSON_PROPERTY_TYPE = "type";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceUnlockUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceUnlockUserResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceUnlockUserResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceUnlockUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceUpdateHumanUserRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceUpdateHumanUserRequest.java
@@ -40,7 +40,7 @@ import java.util.StringJoiner;
   UserServiceUpdateHumanUserRequest.JSON_PROPERTY_PHONE,
   UserServiceUpdateHumanUserRequest.JSON_PROPERTY_PASSWORD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceUpdateHumanUserRequest {
   public static final String JSON_PROPERTY_USERNAME = "username";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceUpdateHumanUserResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceUpdateHumanUserResponse.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   UserServiceUpdateHumanUserResponse.JSON_PROPERTY_EMAIL_CODE,
   UserServiceUpdateHumanUserResponse.JSON_PROPERTY_PHONE_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceUpdateHumanUserResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceUser.java
+++ b/src/main/java/com/zitadel/model/UserServiceUser.java
@@ -46,7 +46,7 @@ import java.util.StringJoiner;
   UserServiceUser.JSON_PROPERTY_HUMAN,
   UserServiceUser.JSON_PROPERTY_MACHINE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceUser {
   public static final String JSON_PROPERTY_USER_ID = "userId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceUserNameQuery.java
+++ b/src/main/java/com/zitadel/model/UserServiceUserNameQuery.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   UserServiceUserNameQuery.JSON_PROPERTY_USER_NAME,
   UserServiceUserNameQuery.JSON_PROPERTY_METHOD
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceUserNameQuery {
   public static final String JSON_PROPERTY_USER_NAME = "userName";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyEmailRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyEmailRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyEmailRequest.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyEmailRequest {
   public static final String JSON_PROPERTY_VERIFICATION_CODE = "verificationCode";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyEmailResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyEmailResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyEmailResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyEmailResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceVerifyInviteCodeRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyInviteCodeRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyInviteCodeRequest.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyInviteCodeRequest {
   public static final String JSON_PROPERTY_VERIFICATION_CODE = "verificationCode";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyInviteCodeResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyInviteCodeResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyInviteCodeResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyInviteCodeResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceVerifyPasskeyRegistrationRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyPasskeyRegistrationRequest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceVerifyPasskeyRegistrationRequest.JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL,
   UserServiceVerifyPasskeyRegistrationRequest.JSON_PROPERTY_PASSKEY_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyPasskeyRegistrationRequest {
   public static final String JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL = "publicKeyCredential";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyPasskeyRegistrationResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyPasskeyRegistrationResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyPasskeyRegistrationResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyPasskeyRegistrationResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceVerifyPhoneRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyPhoneRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyPhoneRequest.JSON_PROPERTY_VERIFICATION_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyPhoneRequest {
   public static final String JSON_PROPERTY_VERIFICATION_CODE = "verificationCode";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyPhoneResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyPhoneResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyPhoneResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyPhoneResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceVerifyTOTPRegistrationRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyTOTPRegistrationRequest.java
@@ -32,7 +32,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyTOTPRegistrationRequest.JSON_PROPERTY_CODE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyTOTPRegistrationRequest {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyTOTPRegistrationResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyTOTPRegistrationResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyTOTPRegistrationResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyTOTPRegistrationResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/UserServiceVerifyU2FRegistrationRequest.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyU2FRegistrationRequest.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
   UserServiceVerifyU2FRegistrationRequest.JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL,
   UserServiceVerifyU2FRegistrationRequest.JSON_PROPERTY_TOKEN_NAME
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyU2FRegistrationRequest {
   public static final String JSON_PROPERTY_PUBLIC_KEY_CREDENTIAL = "publicKeyCredential";
   @javax.annotation.Nonnull

--- a/src/main/java/com/zitadel/model/UserServiceVerifyU2FRegistrationResponse.java
+++ b/src/main/java/com/zitadel/model/UserServiceVerifyU2FRegistrationResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   UserServiceVerifyU2FRegistrationResponse.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class UserServiceVerifyU2FRegistrationResponse {
   public static final String JSON_PROPERTY_DETAILS = "details";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaActivateWebKeyResponse.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaActivateWebKeyResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   WebKeyServiceBetaActivateWebKeyResponse.JSON_PROPERTY_CHANGE_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaActivateWebKeyResponse {
   public static final String JSON_PROPERTY_CHANGE_DATE = "changeDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaCreateWebKeyResponse.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaCreateWebKeyResponse.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   WebKeyServiceBetaCreateWebKeyResponse.JSON_PROPERTY_ID,
   WebKeyServiceBetaCreateWebKeyResponse.JSON_PROPERTY_CREATION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaCreateWebKeyResponse {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaDeleteWebKeyResponse.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaDeleteWebKeyResponse.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   WebKeyServiceBetaDeleteWebKeyResponse.JSON_PROPERTY_DELETION_DATE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaDeleteWebKeyResponse {
   public static final String JSON_PROPERTY_DELETION_DATE = "deletionDate";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaECDSA.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaECDSA.java
@@ -33,7 +33,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   WebKeyServiceBetaECDSA.JSON_PROPERTY_CURVE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaECDSA {
   public static final String JSON_PROPERTY_CURVE = "curve";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaListWebKeysResponse.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaListWebKeysResponse.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   WebKeyServiceBetaListWebKeysResponse.JSON_PROPERTY_WEB_KEYS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaListWebKeysResponse {
   public static final String JSON_PROPERTY_WEB_KEYS = "webKeys";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaRSA.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaRSA.java
@@ -35,7 +35,7 @@ import java.util.StringJoiner;
   WebKeyServiceBetaRSA.JSON_PROPERTY_BITS,
   WebKeyServiceBetaRSA.JSON_PROPERTY_HASHER
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaRSA {
   public static final String JSON_PROPERTY_BITS = "bits";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceBetaWebKey.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceBetaWebKey.java
@@ -42,7 +42,7 @@ import java.util.StringJoiner;
   WebKeyServiceBetaWebKey.JSON_PROPERTY_ECDSA,
   WebKeyServiceBetaWebKey.JSON_PROPERTY_ED25519
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceBetaWebKey {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceCreateWebKeyRequest.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceCreateWebKeyRequest.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
   WebKeyServiceCreateWebKeyRequest.JSON_PROPERTY_ECDSA,
   WebKeyServiceCreateWebKeyRequest.JSON_PROPERTY_ED25519
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceCreateWebKeyRequest {
   public static final String JSON_PROPERTY_RSA = "rsa";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceProtobufAny.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceProtobufAny.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   WebKeyServiceProtobufAny.JSON_PROPERTY_AT_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceProtobufAny extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_AT_TYPE = "@type";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/WebKeyServiceRpcStatus.java
+++ b/src/main/java/com/zitadel/model/WebKeyServiceRpcStatus.java
@@ -38,7 +38,7 @@ import java.util.StringJoiner;
   WebKeyServiceRpcStatus.JSON_PROPERTY_MESSAGE,
   WebKeyServiceRpcStatus.JSON_PROPERTY_DETAILS
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class WebKeyServiceRpcStatus {
   public static final String JSON_PROPERTY_CODE = "code";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/Zitadelobjectv2Organization.java
+++ b/src/main/java/com/zitadel/model/Zitadelobjectv2Organization.java
@@ -34,7 +34,7 @@ import java.util.StringJoiner;
   Zitadelobjectv2Organization.JSON_PROPERTY_ORG_DOMAIN
 })
 @JsonTypeName("zitadelobjectv2Organization")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class Zitadelobjectv2Organization {
   public static final String JSON_PROPERTY_ORG_ID = "orgId";
   @javax.annotation.Nullable

--- a/src/main/java/com/zitadel/model/Zitadelorgv2Organization.java
+++ b/src/main/java/com/zitadel/model/Zitadelorgv2Organization.java
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
   Zitadelorgv2Organization.JSON_PROPERTY_PRIMARY_DOMAIN
 })
 @JsonTypeName("zitadelorgv2Organization")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.12.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class Zitadelorgv2Organization {
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable


### PR DESCRIPTION
## Description

This PR cleans up the public API in our generated SDK.

Helper methods like `...Raw`, `...withHttpInfo`, or those with extra header parameters are now private. This leaves a single, simple public method for each API operation.

## Related Issue

This change makes our SDKs much easier and more intuitive for developers to use. The previous design exposed multiple internal methods, cluttering the API and causing confusion. This cleanup provides a simple and obvious entry point for every API call.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

* All SDKs were regenerated using the new, cleaner templates.
* All existing unit and integration tests were run against the new code and passed, confirming that no functionality was broken.

## Documentation:

The generated code documentation is now cleaner by default. No other documentation changes are needed.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
