### PR TITLE
docs: correct the documented minimum Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Zitadel website and obtain the necessary credentials to access the API.
 
 ### Minimum Requirements
 
-Ensure you have Java 8 or higher installed. You also need Maven to
+Ensure you have Java 11 or higher installed. You also need Maven to
 install dependencies.
 
 ## Using the SDK
@@ -49,7 +49,7 @@ Add the SDK dependency to your `pom.xml`:
 <dependency>
     <groupId>io.github.zitadel</groupId>
     <artifactId>client</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version>3.11.2</version>
         <configuration>
           <doclint>none</doclint>
-          <source>1.8</source>
+          <source>11</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Description

Corrects the documented minimum Java version and the one build setting that was inconsistent with it.

- `README.md`: minimum requirement `Java 8` → `Java 11`.
- `pom.xml`: `maven-javadoc-plugin` `<source>1.8</source>` → `<source>11</source>`, aligning it with the compiler's `<release>11</release>`.
- `README.md`: installation snippet `4.1.0` → `4.1.2` to match the latest release.

## Related Issue

Closes #136

## Motivation and Context

The README tells users that Java 8 or higher is enough, but the project has not been buildable or consumable on Java 8 for some time:

- `pom.xml` sets `maven-compiler-plugin` to `<release>11</release>`, so the published artifact is class file major version 55.
- `.github/workflows/integration.yml` only ever runs the matrix against Java 11, 17 and 21.

A user on Java 8 therefore hits a compilation failure with no hint that the documented requirement is stale. The javadoc plugin was still pinned to `<source>1.8</source>`, a leftover from the same migration.

No supported configuration changes here — this documents what the build already enforces.

A note on the `4.1.0` → `4.1.2` bump in the installation snippet: nothing in `.releaserc.json` updates the README, so this number appears to drift manually between releases. Happy to drop that hunk if you would rather keep it out of a docs fix, or to wire the README into the release config in a separate PR if that is preferable.

## How Has This Been Tested?

Locally on Temurin 21.0.11 / Maven 3.9.16:

- `mvn spotless:check test` — BUILD SUCCESS, 18/18 tests pass, no formatting violations.
- `mvn javadoc:javadoc` — BUILD SUCCESS with the updated `<source>11</source>`.

## Documentation:

The README change is itself the documentation update.

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
